### PR TITLE
Added extra parameter to pass extra arg to clang-tidy

### DIFF
--- a/tests/capture_tools_output/test_database_path.py
+++ b/tests/capture_tools_output/test_database_path.py
@@ -48,6 +48,7 @@ def test_db_detection(
         lines_changed_only=0,  # analyze complete file
         database=database,
         repo_root=rel_root,
+        extra_arg="",
     )
     matched_args = []
     for record in caplog.records:

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -113,6 +113,7 @@ def test_format_annotations(
         lines_changed_only=lines_changed_only,
         database="",
         repo_root="",
+        extra_arg="",
     )
     assert "Output from `clang-tidy`" not in cpp_linter.Globals.OUTPUT
     caplog.set_level(logging.INFO, logger=log_commander.name)
@@ -162,6 +163,7 @@ def test_tidy_annotations(
         lines_changed_only=lines_changed_only,
         database="",
         repo_root="",
+        extra_arg="",
     )
     assert "Run `clang-format` on the following files" not in cpp_linter.Globals.OUTPUT
     caplog.set_level(logging.INFO, logger=log_commander.name)
@@ -195,6 +197,7 @@ def test_diff_comment(lines_changed_only: int):
         lines_changed_only=lines_changed_only,
         database="",
         repo_root="",
+        extra_arg="",
     )
     diff_comments = list_diff_comments(lines_changed_only)
     # output = Path(__file__).parent / "diff_comments.json"

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -36,6 +36,7 @@ class Args:
     files_changed_only: bool = False
     thread_comments: bool = False
     file_annotations: bool = True
+    extra_arg: str = ""
 
 
 def test_defaults():
@@ -62,6 +63,7 @@ def test_defaults():
         ("files-changed-only", "True", "files_changed_only", True),
         ("thread-comments", "True", "thread_comments", True),
         ("file-annotations", "False", "file_annotations", False),
+        ("extra-arg", "-std=c++17", "extra_arg", "-std=c++17"),
     ],
 )
 def test_arg_parser(


### PR DESCRIPTION
Solves cpp-linter/cpp-linter#7 by adding a parameter `--extra-arg` to `cpp-linter`.