### PR TITLE
resolves #24

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build docs
         run: sphinx-build docs docs/_build/html
 
-      - name: Deploy to gh-pages
+      - name: upload docs build as artifact
         uses: actions/upload-artifact@v3
         with:
           name: "cpp-linter_docs"

--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.x'
       - run: python3 -m pip install pre-commit
       - run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -13,12 +13,12 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/python/black
-    rev: '22.6.0'
+    rev: '23.3.0'
     hooks:
       - id: black
         args: ["--diff"]
   - repo: https://github.com/pycqa/pylint
-    rev: v2.14.5
+    rev: v3.0.0a6
     hooks:
       - id: pylint
         name: pylint (action code)

--- a/cpp_linter/__init__.py
+++ b/cpp_linter/__init__.py
@@ -61,9 +61,10 @@ def make_headers(use_diff: bool = False) -> Dict[str, str]:
 class Globals:
     """Global variables for re-use (non-constant)."""
 
-    PAYLOAD_TIDY: str = ""
+    TIDY_COMMENT: str = ""
     """The accumulated output of clang-tidy (gets appended to OUTPUT)"""
-    OUTPUT: str = ""
+    FORMAT_COMMENT: str = ""
+    OUTPUT: str = "<!-- cpp linter action -->\n# Cpp-Linter Report "
     """The accumulated body of the resulting comment that gets posted."""
     FILES: List[Dict[str, Any]] = []
     """The responding payload containing info about changed files."""

--- a/cpp_linter/clang_tidy.py
+++ b/cpp_linter/clang_tidy.py
@@ -1,5 +1,6 @@
 """Parse output from clang-tidy's stdout"""
 from pathlib import Path, PurePath
+from textwrap import indent
 import re
 from typing import Tuple, Union, List, cast
 from . import GlobalParser, CLANG_TIDY_STDOUT
@@ -56,17 +57,11 @@ class TidyNotification:
                 PurePath(self.filename).suffix.lstrip("."),
                 "\n".join(self.fixit_lines),
             )
-        return (
-            "<details open>\n<summary><strong>{}:{}:{}:</strong> {}: [{}]"
-            "\n\n> {}\n</summary><p>\n\n{}</p>\n</details>\n\n".format(
-                self.filename,
-                self.line,
-                self.cols,
-                self.note_type,
-                self.diagnostic,
-                self.note_info,
-                concerned_code,
-            )
+        return indent(
+            f"<strong>{self.filename}:{self.line}:{self.cols}:</strong> "
+            + f"{self.note_type}: [{self.diagnostic}]\n> {self.note_info}"
+            + f"\n\n{concerned_code}\n",
+            "   "
         )
 
     def log_command(self) -> str:

--- a/cpp_linter/clang_tidy.py
+++ b/cpp_linter/clang_tidy.py
@@ -5,7 +5,7 @@ import re
 from typing import Tuple, Union, List, cast
 from . import GlobalParser, CLANG_TIDY_STDOUT
 
-NOTE_HEADER = re.compile(r"^(.*):(\d+):(\d+):\s(\w+):(.*)\[(.*)\]$")
+NOTE_HEADER = re.compile(r"^(.+):(\d+):(\d+):\s(\w+):(.*)\[(.*)\]$")
 
 
 class TidyNotification:

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -183,6 +183,16 @@ thread comments as feedback.
 Defaults to ``%(default)s``.""",
 )
 cli_arg_parser.add_argument(
+    "-w",
+    "--step-summary",
+    default="false",
+    type=lambda input: input.lower() == "true",
+    help="""Set this option to true or false to enable or disable the use of
+a workflow step summary when the run has concluded.
+
+Defaults to ``%(default)s``.""",
+)
+cli_arg_parser.add_argument(
     "-a",
     "--file-annotations",
     default="true",

--- a/cpp_linter/git.py
+++ b/cpp_linter/git.py
@@ -112,14 +112,14 @@ def parse_diff(full_diff: str) -> List[Dict[str, Any]]:
         if filename_match is None:
             continue
         filename = filename_match.groups(0)[0]
-        file_objects.append(dict(filename=filename))
+        file_objects.append({"filename": filename})
         if first_hunk is None:
             continue
         ranges, additions = parse_patch(diff[first_hunk.start() :])
-        file_objects[-1]["line_filter"] = dict(
-            diff_chunks=ranges,
-            lines_added=consolidate_list_to_ranges(additions),
-        )
+        file_objects[-1]["line_filter"] = {
+            "diff_chunks": ranges,
+            "lines_added": consolidate_list_to_ranges(additions),
+        }
     return file_objects
 
 

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -476,17 +476,18 @@ def capture_clang_tools_output(
         create_comment_body(filename, file, lines_changed_only, tidy_notes)
 
     if Globals.FORMAT_COMMENT or Globals.TIDY_COMMENT:
-        Globals.OUTPUT += ":warning:\nSome files did not pass the configured checks!"
+        Globals.OUTPUT += ":warning:\nSome files did not pass the configured checks!\n"
         if Globals.FORMAT_COMMENT:
             Globals.OUTPUT += (
-                "<details><summary>clang-format reports: <strong>"
-                + f"{len(GlobalParser.format_advice)} file(s) not formatted</strong>\n"
-                + f"\n{Globals.FORMAT_COMMENT}\n\n</details>"
+                "\n<details><summary>clang-format reports: <strong>"
+                + f"{len(GlobalParser.format_advice)} file(s) not formatted</strong>"
+                + f"</summary>\n\n{Globals.FORMAT_COMMENT}\n\n</details>"
             )
         if Globals.TIDY_COMMENT:
             Globals.OUTPUT += (
-                f"<details><summary>clang-tidy reports: <strong>{len(tidy_notes)} "
-                + f"concern(s)</strong>\n\n{Globals.TIDY_COMMENT}\n\n</details>"
+                f"\n<details><summary>clang-tidy reports: <strong>{len(tidy_notes)} "
+                + f"concern(s)</strong></summary>\n\n{Globals.TIDY_COMMENT}\n\n"
+                + "</details>"
             )
     else:
         Globals.OUTPUT += ":heavy_check_mark:\nNo problems need attention."

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -249,7 +249,7 @@ def list_source_files(
                 if not is_file_in_list(
                     ignored_paths, file_path, "ignored"
                 ) or is_file_in_list(not_ignored, file_path, "not ignored"):
-                    Globals.FILES.append(dict(filename=file_path))
+                    Globals.FILES.append({"filename": file_path})
 
     if Globals.FILES:
         logger.info(
@@ -318,9 +318,10 @@ def run_clang_tidy(
         if not PurePath(database).is_absolute():
             database = str(Path(RUNNER_WORKSPACE, repo_root, database).resolve())
         cmds.append(database)
-    line_ranges = dict(
-        name=filename, lines=range_of_changed_lines(file_obj, lines_changed_only, True)
-    )
+    line_ranges = {
+        "name": filename,
+        "lines": range_of_changed_lines(file_obj, lines_changed_only, True),
+    }
     if line_ranges["lines"]:
         # logger.info("line_filter = %s", json.dumps([line_ranges]))
         cmds.append(f"--line-filter={json.dumps([line_ranges])}")

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -490,8 +490,8 @@ def capture_clang_tools_output(
             )
     else:
         Globals.OUTPUT += ":heavy_check_mark:\nNo problems need attention."
-    Globals.OUTPUT += "Have any feedback or feature suggestions? [Share it here.]"
-    Globals.OUTPUT += "(https://github.com/cpp-linter/cpp-linter/issues)"
+    Globals.OUTPUT += "\n\nHave any feedback or feature suggestions? [Share it here.]"
+    Globals.OUTPUT += "(https://github.com/cpp-linter/cpp-linter-action/issues)"
 
     GlobalParser.tidy_notes = tidy_notes[:]  # restore cache of notifications
 
@@ -820,6 +820,9 @@ def main():
         )
     if args.thread_comments and thread_comments_allowed:
         post_results(False)  # False is hard-coded to disable diff comments.
+    if args.step_summary and "GITHUB_STEP_SUMMARY" in os.environ:
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+            summary.write(f"\n{Globals.OUTPUT}\n")
     set_exit_code(
         int(
             make_annotations(args.style, args.file_annotations, args.lines_changed_only)

--- a/cpp_linter/thread_comments.py
+++ b/cpp_linter/thread_comments.py
@@ -105,13 +105,13 @@ def aggregate_tidy_advice(lines_changed_only: int) -> List[Dict[str, Any]]:
                 body += suggestion
 
             results.append(
-                dict(
-                    body=body,
-                    commit_id=GITHUB_SHA,
-                    line=diag.line,
-                    path=fixit.filename,
-                    side="RIGHT",
-                )
+                {
+                    "body": body,
+                    "commit_id": GITHUB_SHA,
+                    "line": diag.line,
+                    "path": fixit.filename,
+                    "side": "RIGHT",
+                }
             )
     return results
 
@@ -162,13 +162,13 @@ def aggregate_format_advice(lines_changed_only: int) -> List[Dict[str, Any]]:
 
             # create a suggestion from clang-format advice
             results.append(
-                dict(
-                    body=body,
-                    commit_id=GITHUB_SHA,
-                    line=fixed_line.line,
-                    path=fmt_advice.filename,
-                    side="RIGHT",
-                )
+                {
+                    "body": body,
+                    "commit_id": GITHUB_SHA,
+                    "line": fixed_line.line,
+                    "path": fmt_advice.filename,
+                    "side": "RIGHT",
+                }
             )
     return results
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,7 +356,7 @@ min-public-methods = 1
 
 [tool.pylint.exceptions]
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions = ["Exception"]
+overgeneral-exceptions = ["builtins.Exception"]
 
 [tool.pylint.format]
 # Expected format of line ending, e.g. empty (any line ending), LF or CRLF.

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -49,6 +49,8 @@ def _translate_lines_changed_only_value(value: int) -> str:
 def flush_prior_artifacts():
     """flush output from any previous tests"""
     cpp_linter.Globals.OUTPUT = ""
+    cpp_linter.Globals.TIDY_COMMENT = ""
+    cpp_linter.Globals.FORMAT_COMMENT = ""
     cpp_linter.Globals.FILES.clear()
     cpp_linter.GlobalParser.format_advice.clear()
     cpp_linter.GlobalParser.tidy_advice.clear()
@@ -339,3 +341,23 @@ def test_diff_comment(
             continue
         ranges = cpp_linter.range_of_changed_lines(file, lines_changed_only)
         assert comment["line"] in ranges
+
+
+def test_LGTM_comment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Verify the comment is affirmative when no attention is warranted."""
+    monkeypatch.chdir(str(tmp_path))
+    flush_prior_artifacts()
+    # monkeypatch.setattr(cpp_linter.Globals, "OUTPUT", "")
+    # monkeypatch.setattr(cpp_linter.Globals, "FILES", [])
+
+    # this call essentially does nothing with the file system
+    capture_clang_tools_output(
+        version=CLANG_VERSION,
+        checks="-*",
+        style="",
+        lines_changed_only=0,
+        database="",
+        repo_root="",
+        extra_args=[],
+    )
+    assert "No problems need attention." in cpp_linter.Globals.OUTPUT

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -35,6 +35,7 @@ class Args:
     lines_changed_only: int = 0
     files_changed_only: bool = False
     thread_comments: bool = False
+    step_summary: bool = False
     file_annotations: bool = True
     extra_arg: List[str] = []
 
@@ -62,6 +63,7 @@ def test_defaults():
         ("lines-changed-only", "difF", "lines_changed_only", 1),
         ("files-changed-only", "True", "files_changed_only", True),
         ("thread-comments", "True", "thread_comments", True),
+        ("step-summary", "True", "step_summary", True),
         ("file-annotations", "False", "file_annotations", False),
         ("extra-arg", "-std=c++17", "extra_arg", ["-std=c++17"]),
         ("extra-arg", '"-std=c++17 -Wall"', "extra_arg", ['"-std=c++17 -Wall"']),


### PR DESCRIPTION
Revised the comments per suggestions from discussion in #24 

I also introduced a new `--step-summary` to allow using [`GITHUB_STEP_SUMMARY`](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary) feature. The summary posted has the same content as the `--thread-comments` feature.

Lastly, pylint has updated their support for python 3.11, so we can now use the latest python version again in CI. I also fixed some other warnings pylint didn't like about using `dict(...)` instead of literal `{...}`.