### PR TITLE
use compile_commands.json to normalize paths from tidy's stdout

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
 
@@ -19,7 +19,7 @@ jobs:
         run: sphinx-build docs docs/_build/html
 
       - name: upload docs build as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "cpp-linter_docs"
           path: ${{ github.workspace }}/docs/_build/html

--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -9,8 +9,8 @@ jobs:
   check-source-files:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - run: python3 -m pip install pre-commit

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       # use fetch --all for setuptools_scm to work
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -23,14 +23,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Build wheel
         run: python3 -m pip wheel --no-deps -w dist .
       - name: Upload wheel as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cpp-linter_wheel
           path: ${{ github.workspace }}/dist/*.whl
@@ -46,14 +46,14 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
 
       - name: download wheel artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cpp-linter_wheel
           path: dist
@@ -83,7 +83,7 @@ jobs:
           python -m pip install clang-tools
           clang-tools --install ${{ matrix.version }}
 
-      - name: Collect Coverage (native clang install)
+      - name: Collect Coverage
         env:
           CLANG_VERSION: ${{ matrix.version }}
         run: coverage run -m pytest

--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -96,10 +96,45 @@ jobs:
           CLANG_VERSION: ${{ matrix.version }}
         run: coverage run -m pytest
 
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-${{ runner.os }}-py${{ matrix.py }}-${{ matrix.version }}
+          path: .coverage*
+
+  coverage-report:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ci-artifacts
+
+      - run: mv ci-artifacts/**/.coverage* ./
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Create coverage report
+        run: |
+          pip3 install coverage[toml]
+          coverage combine
+          coverage html
+
+      - name: Upload comprehensive coverage HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: htmlcov/
+
       - run: coverage report && coverage xml
 
       - uses: codecov/codecov-action@v3
-        if: runner.os == 'Linux' && matrix.version == '15' && matrix.py == '3.10'
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml

--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -63,6 +63,14 @@ jobs:
         shell: bash
         run: python3 -m pip install pytest coverage[toml] meson dist/*.whl
 
+      # https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages
+      - name: Install ninja (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install ninja-build
+      - name: Install ninja (Windows)
+        if: runner.os == 'Windows'
+        run: choco install ninja
+
       - name: Install Linux clang dependencies
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -40,23 +40,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: ['3.7', '3.8', '3.9', '3.10']
+        py: ['3.8', '3.9', '3.10', '3.11']
         os: ['windows-latest', ubuntu-22.04]
-        version: ['15', '14', '13', '12', '11', '10', '9', '8', '7']
-        include:
-          # mark all matrix jobs as "need to install clang-tools"
-          - tools_dir: 'temp'
-
-          # mark certain matrix jobs as "use natively installed clang-tools"
-          - os: 'windows-latest'
-            version: '14'
-            tools_dir: 'N/A'
-          - os: 'ubuntu-22.04'
-            version: '14'
-            tools_dir: 'N/A'
-          - os: 'ubuntu-22.04'
-            version: '13'
-            tools_dir: 'N/A'
+        version: ['17', '16', '15', '14', '13', '12', '11', '10', '9', '8', '7']
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -77,28 +63,35 @@ jobs:
         shell: bash
         run: python3 -m pip install pytest coverage[toml] dist/*.whl
 
+      - name: Install Linux clang dependencies
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          # First try installing from default Ubuntu repositories before trying LLVM script
+          if ! sudo apt-get install -y clang-format-${{ matrix.version }} clang-tidy-${{ matrix.version }}; then
+            # This LLVM script will add the relevant LLVM PPA: https://apt.llvm.org/
+            wget https://apt.llvm.org/llvm.sh -O ${{ runner.temp }}/llvm_install.sh
+            chmod +x ${{ runner.temp }}/llvm_install.sh
+            if sudo ${{ runner.temp }}/llvm_install.sh ${{ matrix.version }}; then
+              sudo apt-get install -y clang-format-${{ matrix.version }} clang-tidy-${{ matrix.version }}
+            fi
+          fi
+
       - name: Install clang-tools
-        if: matrix.tools_dir == 'temp'
         run: |
           python -m pip install clang-tools
-          clang-tools --install ${{ matrix.version }}  --directory ${{ runner.temp }}/clang-tools
+          clang-tools --install ${{ matrix.version }}
 
       - name: Collect Coverage (native clang install)
-        if: matrix.tools_dir == 'N/A'
         env:
           CLANG_VERSION: ${{ matrix.version }}
-        run: coverage run -m pytest
-
-      - name: Collect Coverage (non-native clang install)
-        if: matrix.tools_dir == 'temp'
-        env:
-          CLANG_VERSION: ${{ runner.temp }}/clang-tools
         run: coverage run -m pytest
 
       - run: coverage report && coverage xml
 
       - uses: codecov/codecov-action@v3
-        if: matrix.os == 'ubuntu-22.04' && matrix.version == '12' && matrix.py == '3.10'
+        if: runner.os == 'Linux' && matrix.version == '15' && matrix.py == '3.10'
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml

--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install workflow deps
         # using a wildcard as filename on Windows requires a bash shell
         shell: bash
-        run: python3 -m pip install pytest coverage[toml] dist/*.whl
+        run: python3 -m pip install pytest coverage[toml] meson dist/*.whl
 
       - name: Install Linux clang dependencies
         if: runner.os == 'Linux'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,4 @@ repos:
         types: [python]
         entry: mypy
         exclude: "^(docs/|setup.py$)"
-        additional_dependencies: [mypy, types-pyyaml, types-requests, rich, requests, pytest, pyyaml, '.']
+        additional_dependencies: [mypy, types-pyyaml, types-requests, rich, requests, pytest, pyyaml, meson, '.']

--- a/cpp_linter/clang_tidy.py
+++ b/cpp_linter/clang_tidy.py
@@ -47,8 +47,7 @@ class TidyNotification:
             .as_posix()
             .replace(Path.cwd().as_posix() + "/", "")
         )
-        if not PurePath(self.filename).is_absolute():
-            if database is not None:
+        if not PurePath(self.filename).is_absolute() and database is not None:
                 # get absolute path from compilation database:
                 # This is need for meson builds as they use paths relative to
                 # the build env (or wherever the database is usually located).

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -275,7 +275,6 @@ def run_clang_tidy(
     checks: str,
     lines_changed_only: int,
     database: str,
-    repo_root: str,
     extra_args: List[str],
 ) -> None:
     """Run clang-tidy on a certain file.
@@ -471,7 +470,6 @@ def capture_clang_tools_output(
             checks,
             lines_changed_only,
             database,
-            repo_root,
             extra_args,
         )
         run_clang_format(file, version, style, lines_changed_only)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ testpaths = ["tests"]
 [tool.coverage]
 [tool.coverage.run]
 dynamic_context = "test_function"
+# These options are useful if combining coverage data from multiple tested envs
+parallel = true
+relative_files = true
 omit = [
     # don't include tests in coverage
     "tests/*",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 coverage[toml]
+meson
 mypy
 pre-commit
 pytest

--- a/tests/capture_tools_output/test_database_path.py
+++ b/tests/capture_tools_output/test_database_path.py
@@ -117,9 +117,13 @@ def test_ninja_database(
         repo_root=".",  # already changed cwd
         extra_args=[],
     )
+    found_project_file = False
     for note in cpp_linter.GlobalParser.tidy_notes:
         if note.filename.endswith("demo.cpp") or note.filename.endswith("demo.hpp"):
             assert not Path(note.filename).is_absolute()
+            found_project_file = True
+    if not found_project_file:
+        raise RuntimeError("no project files raised concerns with clang-tidy")
     assert make_annotations("", True, 0)
     # write step-summary for manual verification
     Path(tmp_path, "job_summary.md").write_text(

--- a/tests/capture_tools_output/test_database_path.py
+++ b/tests/capture_tools_output/test_database_path.py
@@ -96,7 +96,7 @@ def test_ninja_database(
     monkeypatch.setattr(
         cpp_linter.Globals,
         "FILES",
-        [FileObj("demo.cpp", [], []), FileObj("demo.hpp", [], [])],
+        [FileObj("demo.cpp", [], [])],
     )
     for attr in ["OUTPUT", "FORMAT_COMMENT", "TIDY_COMMENT"]:
         monkeypatch.setattr(cpp_linter.Globals, attr, "")

--- a/tests/capture_tools_output/test_database_path.py
+++ b/tests/capture_tools_output/test_database_path.py
@@ -60,7 +60,7 @@ def test_db_detection(
         assert "Error while trying to load a compilation database" not in record.message
         msg_match = CLANG_TIDY_COMMAND.search(record.message)
         if msg_match is not None:
-            matched_args = msg_match.group(0).split()[2:]
+            matched_args = msg_match.group(0).split()[1:]
             break
     else:
         raise RuntimeError("failed to find args passed in clang-tidy in log records")

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -352,6 +352,7 @@ def test_diff_comment(
     comments (not annotations) in the event's diff.
 
     Remember, diff comments should only focus on lines in the diff."""
+    monkeypatch.setenv("CPP_LINTER_TEST_ALPHA_CODE", "true")
     prep_tmp_dir(
         tmp_path,
         monkeypatch,


### PR DESCRIPTION
This goes against my instincts as using the compilation database in post-processing seems like it would be out of this project's scope, but there doesn't seem to be a better way (other than telling users to manually make relative paths into absolute paths in the database before running cpp-linter).

This would resolve #30 and #43 