### PR TITLE
improve version comprehension

### DIFF
--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -456,10 +456,15 @@ def capture_clang_tools_output(
         format_cmd = assemble_version_exec("clang-format", version)
         assert format_cmd is not None, "clang-format executable was not found"
         show_tool_version_output(format_cmd)
+    else:  # clear any clang-format XML artifact from previous runs
+        CLANG_FORMAT_XML.unlink(missing_ok=True)
     if checks != "-*":  # if all checks are disabled, then clang-tidy is skipped
         tidy_cmd = assemble_version_exec("clang-tidy", version)
         assert tidy_cmd is not None, "clang-tidy executable was not found"
         show_tool_version_output(tidy_cmd)
+    else:  # clear any clang-tidy artifacts from previous runs
+        CLANG_TIDY_STDOUT.unlink(missing_ok=True)
+        CLANG_TIDY_YML.unlink(missing_ok=True)
 
     db_json: Optional[List[Dict[str, str]]] = None
     if database and not PurePath(database).is_absolute():

--- a/cpp_linter/run.py
+++ b/cpp_linter/run.py
@@ -17,6 +17,7 @@ import json
 import urllib.parse
 import logging
 from typing import cast, List, Tuple, Optional, Dict
+from textwrap import indent
 import requests
 from . import (
     Globals,
@@ -270,8 +271,8 @@ def list_source_files(
 
 
 def run_clang_tidy(
+    command: str,
     file_obj: FileObj,
-    version: str,
     checks: str,
     lines_changed_only: int,
     database: str,
@@ -305,12 +306,8 @@ def run_clang_tidy(
 
                 cpp-linter --extra-arg=-std=c++14 --extra-arg=-Wall
     """
-    if checks == "-*":  # if all checks are disabled, then clang-tidy is skipped
-        # clear the clang-tidy output file and exit function
-        CLANG_TIDY_STDOUT.write_bytes(b"")
-        return
     filename = file_obj.name.replace("/", os.sep)
-    cmds = [assemble_version_exec("clang-tidy", version)]
+    cmds = [command]
     if "CPP_LINTER_TEST_ALPHA_CODE" in os.environ:
         cmds.append(f"--export-fixes={str(CLANG_TIDY_YML)}")
         # clear yml file's content before running clang-tidy
@@ -345,8 +342,8 @@ def run_clang_tidy(
 
 
 def run_clang_format(
+    command: str,
     file_obj: FileObj,
-    version: str,
     style: str,
     lines_changed_only: int,
 ) -> None:
@@ -359,11 +356,8 @@ def run_clang_format(
     :param lines_changed_only: A flag that forces focus on only changes in the event's
         diff info.
     """
-    if not style:
-        CLANG_FORMAT_XML.write_bytes(b"")
-        return  # clear any previous output and exit
     cmds = [
-        assemble_version_exec("clang-format", version),
+        command,
         f"-style={style}",
         "--output-replacements-xml",
     ]
@@ -451,9 +445,25 @@ def capture_clang_tools_output(
         arguments.
     """
 
+    def show_tool_version_output(cmd: str):  # show version output for executable used
+        version_out = subprocess.run(
+            [cmd, "--version"], capture_output=True, check=True
+        )
+        logger.info("%s --version\n%s", cmd, indent(version_out.stdout.decode(), "\t"))
+
+    tidy_cmd, format_cmd = (None, None)
+    if style:  # if style is an empty value, then clang-format is skipped
+        format_cmd = assemble_version_exec("clang-format", version)
+        assert format_cmd is not None, "clang-format executable was not found"
+        show_tool_version_output(format_cmd)
+    if checks != "-*":  # if all checks are disabled, then clang-tidy is skipped
+        tidy_cmd = assemble_version_exec("clang-tidy", version)
+        assert tidy_cmd is not None, "clang-tidy executable was not found"
+        show_tool_version_output(tidy_cmd)
+
+    db_json: Optional[List[Dict[str, str]]] = None
     if database and not PurePath(database).is_absolute():
         database = str(Path(RUNNER_WORKSPACE, repo_root, database).resolve())
-    db_json: Optional[List[Dict[str, str]]] = None
     if database:
         db_path = Path(database, "compile_commands.json")
         if db_path.exists():
@@ -463,15 +473,17 @@ def capture_clang_tools_output(
     tidy_notes: List[TidyNotification] = []
     for file in Globals.FILES:
         start_log_group(f"Performing checkup on {file.name}")
-        run_clang_tidy(
-            file,
-            version,
-            checks,
-            lines_changed_only,
-            database,
-            extra_args,
-        )
-        run_clang_format(file, version, style, lines_changed_only)
+        if tidy_cmd is not None:
+            run_clang_tidy(
+                tidy_cmd,
+                file,
+                checks,
+                lines_changed_only,
+                database,
+                extra_args,
+            )
+        if format_cmd is not None:
+            run_clang_format(format_cmd, file, style, lines_changed_only)
         end_log_group()
 
         create_comment_body(file, lines_changed_only, tidy_notes, db_json)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -180,13 +180,22 @@ def test_serialize_file_obj():
 
 CLANG_VERSION = os.getenv("CLANG_VERSION", "12")
 
+DEFAULT_CLANG_FORMAT_EXE = cast(str, shutil.which("clang-format"))
+
 
 @pytest.mark.parametrize("tool_name", ["clang-format"])
 @pytest.mark.parametrize(
     "version",
-    [CLANG_VERSION, str(Path(cast(str, shutil.which("clang-format"))).parent), ""],
-    ids=["number", "path", "none"],
+    [
+        CLANG_VERSION,
+        str(Path(DEFAULT_CLANG_FORMAT_EXE).parent),
+        str(Path(DEFAULT_CLANG_FORMAT_EXE).parent.parent),
+        "",
+    ],
+    ids=["number", "path", "distant_parent_path", "none"],
 )
 def test_tool_exe_path(tool_name: str, version: str):
     """Test specifying the version of the clang tool."""
-    assert assemble_version_exec(tool_name, version)
+    exe_path = assemble_version_exec(tool_name, version)
+    assert exe_path
+    assert tool_name in exe_path

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,12 +3,19 @@ import logging
 import os
 import json
 from pathlib import Path
-from typing import List
+import shutil
+from typing import List, cast
 import pytest
 import requests
 import cpp_linter
 import cpp_linter.run
-from cpp_linter import Globals, log_response_msg, get_line_cnt_from_cols, FileObj
+from cpp_linter import (
+    Globals,
+    log_response_msg,
+    get_line_cnt_from_cols,
+    FileObj,
+    assemble_version_exec,
+)
 from cpp_linter.run import (
     log_commander,
     start_log_group,
@@ -169,3 +176,17 @@ def test_serialize_file_obj():
         + r'"lines_added": [[5, 6], [10, 11]]}}]'
     )
     assert json.dumps([file_obj.serialize()]) == json_obj
+
+
+CLANG_VERSION = os.getenv("CLANG_VERSION", "12")
+
+
+@pytest.mark.parametrize("tool_name", ["clang-format"])
+@pytest.mark.parametrize(
+    "version",
+    [CLANG_VERSION, str(Path(cast(str, shutil.which("clang-format"))).parent), ""],
+    ids=["number", "path", "none"],
+)
+def test_tool_exe_path(tool_name: str, version: str):
+    """Test specifying the version of the clang tool."""
+    assert assemble_version_exec(tool_name, version)


### PR DESCRIPTION
Uses `shutil.which()` to get the path to an existing executable. If specified version is a semantic version number, then it is used as a path to the executable.

Now throws an assertion error if tool executable could not be discovered.

Moved tool skipping to `capture_clang_tools_output()` and show executable's version in logs (for transparency).

added unit test to cover changes