### PR TITLE
make verbosity disabled by default

### DIFF
--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -1,6 +1,7 @@
 """Setup the options for CLI arguments."""
 import argparse
 import logging
+from os import environ
 
 cli_arg_parser = argparse.ArgumentParser(
     description="Run clang-tidy and clang-format on a list of changed files "
@@ -11,7 +12,7 @@ arg = cli_arg_parser.add_argument(
     "-v",
     "--verbosity",
     type=int,
-    default=10,
+    default=20 - (10 if environ.get("ACTIONS_STEP_DEBUG", "") == "true" else 0),
     help="""This controls the action's verbosity in the workflow's logs.
 Supported options are defined by the `logging-level <logging-levels>`_.
 This option does not affect the verbosity of resulting

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,4 +1,5 @@
 """Tests related parsing input from CLI arguments."""
+from os import environ
 from typing import List, Union
 import pytest
 from cpp_linter.run import cli_arg_parser
@@ -8,7 +9,7 @@ class Args:
     """A pseudo namespace declaration. Each attribute is initialized with the
     corresponding CLI arg's default value."""
 
-    verbosity: int = 10
+    verbosity: int = 20 - (10 if environ.get("ACTIONS_STEP_DEBUG", "") == "true" else 0)
     database: str = ""
     style: str = "llvm"
     tidy_checks: str = (


### PR DESCRIPTION
Users can still enable verbosity by [re-running a CI job with debugging logs enabled](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging).

Not outputting debug info in production will save users CI time.