### PR TITLE
Link clang-tidy diagnostic names to clang-tidy docs

### DIFF
--- a/cpp_linter/clang_tools/__init__.py
+++ b/cpp_linter/clang_tools/__init__.py
@@ -7,7 +7,7 @@ import shutil
 
 from ..common_fs import FileObj
 from ..loggers import start_log_group, end_log_group, logger
-from .clang_tidy import run_clang_tidy, TidyNotification
+from .clang_tidy import run_clang_tidy, TidyAdvice
 from .clang_format import run_clang_format, FormatAdvice
 
 
@@ -39,7 +39,7 @@ def capture_clang_tools_output(
     lines_changed_only: int,
     database: str,
     extra_args: List[str],
-) -> Tuple[List[FormatAdvice], List[List[TidyNotification]]]:
+) -> Tuple[List[FormatAdvice], List[TidyAdvice]]:
     """Execute and capture all output from clang-tidy and clang-format. This aggregates
     results in the :attr:`~cpp_linter.Globals.OUTPUT`.
 
@@ -81,7 +81,7 @@ def capture_clang_tools_output(
             db_json = json.loads(db_path.read_text(encoding="utf-8"))
 
     # temporary cache of parsed notifications for use in log commands
-    tidy_notes: List[List[TidyNotification]] = []
+    tidy_notes: List[TidyAdvice] = []
     format_advice = []
     for file in files:
         start_log_group(f"Performing checkup on {file.name}")

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -34,16 +34,16 @@ class TidyNotification:
             self.line,
             #: The columns of the line that triggered the notification.
             self.cols,
-            self.note_type,
-            self.note_info,
+            self.severity,
+            self.rationale,
             #: The clang-tidy check that enabled the notification.
             self.diagnostic,
         ) = notification_line
 
         #: The rationale of the notification.
-        self.note_info = self.note_info.strip()
+        self.rationale = self.rationale.strip()
         #: The priority level of notification (warning/error).
-        self.note_type = self.note_type.strip()
+        self.severity = self.severity.strip()
         #: The line number of the source file.
         self.line = int(self.line)
         self.cols = int(self.cols)
@@ -74,6 +74,12 @@ class TidyNotification:
         self.filename = rel_path
         #: A `list` of lines for the code-block in the notification.
         self.fixit_lines: List[str] = []
+
+    @property
+    def diagnostic_link(self) -> str:
+        """Creates a markdown link to the diagnostic documentation."""
+        link = f"[{self.diagnostic}](https://clang.llvm.org/extra/clang-tidy/checks/"
+        return link + "{}/{}.html)".format(*self.diagnostic.split("-", maxsplit=1))
 
     def __repr__(self) -> str:
         return (

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -4,7 +4,7 @@ import requests
 from typing import Optional, Dict, List, Tuple
 from ..common_fs import FileObj
 from ..clang_tools.clang_format import FormatAdvice
-from ..clang_tools.clang_tidy import TidyNotification
+from ..clang_tools.clang_tidy import TidyAdvice
 from ..loggers import logger
 
 
@@ -63,7 +63,7 @@ class RestApiClient(ABC):
     def make_comment(
         files: List[FileObj],
         format_advice: List[FormatAdvice],
-        tidy_advice: List[List[TidyNotification]],
+        tidy_advice: List[TidyAdvice],
     ) -> Tuple[str, int, int]:
         """Make an MarkDown comment from the given advice. Also returns a count of
         checks failed for each tool (clang-format and clang-tidy)
@@ -88,8 +88,8 @@ class RestApiClient(ABC):
                 format_checks_failed += 1
 
         tidy_comment = ""
-        for file_obj, notes in zip(files, tidy_advice):
-            for note in notes:
+        for file_obj, concern in zip(files, tidy_advice):
+            for note in concern.notes:
                 if file_obj.name == note.filename:
                     tidy_comment += f"- {file_obj.name}\n\n"
                     tidy_comment += (
@@ -137,7 +137,7 @@ class RestApiClient(ABC):
         self,
         files: List[FileObj],
         format_advice: List[FormatAdvice],
-        tidy_advice: List[List[TidyNotification]],
+        tidy_advice: List[TidyAdvice],
         thread_comments: str,
         no_lgtm: bool,
         step_summary: bool,

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -101,9 +101,9 @@ class RestApiClient(ABC):
                     )
                     tidy_comment += (
                         "{severity}: [{diagnostic}]\n   > {rationale}\n".format(
-                            severity=note.note_type,
-                            diagnostic=note.diagnostic,
-                            rationale=note.note_info,
+                            severity=note.severity,
+                            diagnostic=note.diagnostic_link,
+                            rationale=note.rationale,
                         )
                     )
                     if note.fixit_lines:

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -233,7 +233,9 @@ class GithubApiClient(RestApiClient):
             for n in note:
                 if n.filename == file.name:
                     output = "::{} ".format(
-                        "notice" if n.note_type.startswith("note") else n.note_type
+                        "notice"
+                        if n.severity.startswith("note")
+                        else n.severity
                     )
                     output += "file={file},line={line},title={file}:{line}:".format(
                         file=file.name, line=n.line
@@ -241,7 +243,7 @@ class GithubApiClient(RestApiClient):
                     output += "{cols} [{diag}]::{info}".format(
                         cols=n.cols,
                         diag=n.diagnostic,
-                        info=n.note_info,
+                        info=f"{n.rationale} -- see {n.diagnostic_link}",
                     )
                     log_commander.info(output)
 

--- a/tests/capture_tools_output/test_database_path.py
+++ b/tests/capture_tools_output/test_database_path.py
@@ -11,7 +11,7 @@ from cpp_linter.loggers import logger
 from cpp_linter.common_fs import FileObj, CACHE_PATH
 from cpp_linter.rest_api.github_api import GithubApiClient
 from cpp_linter.clang_tools import capture_clang_tools_output
-from mesonbuild.mesonmain import main as meson  # type: ignore[import-untyped]
+from mesonbuild.mesonmain import main as meson  # type: ignore
 
 CLANG_TIDY_COMMAND = re.compile(r'clang-tidy[^\s]*\s(.*)"')
 
@@ -101,8 +101,8 @@ def test_ninja_database(
         extra_args=[],
     )
     found_project_file = False
-    for notes in tidy_advice:
-        for note in notes:
+    for concern in tidy_advice:
+        for note in concern.notes:
             if note.filename.endswith("demo.cpp") or note.filename.endswith("demo.hpp"):
                 assert not Path(note.filename).is_absolute()
                 found_project_file = True

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -9,7 +9,7 @@ import shutil
 from typing import Dict, cast, List, Optional
 import warnings
 
-import pygit2  # type: ignore[import-not-found]
+import pygit2  # type: ignore
 import pytest
 import requests_mock
 
@@ -253,8 +253,8 @@ def test_format_annotations(
         database="",
         extra_args=[],
     )
-    assert [n for n in format_advice]
-    assert not [n for note in tidy_advice for n in note]
+    assert [note for note in format_advice]
+    assert not [note for concern in tidy_advice for note in concern.notes]
 
     caplog.set_level(logging.INFO, logger=log_commander.name)
     log_commander.propagate = True
@@ -329,8 +329,8 @@ def test_tidy_annotations(
         database="",
         extra_args=[],
     )
-    assert [n for note in tidy_advice for n in note]
-    assert not [n for n in format_advice]
+    assert [note for concern in tidy_advice for note in concern.notes]
+    assert not [note for note in format_advice]
     caplog.set_level(logging.DEBUG)
     log_commander.propagate = True
     gh_client.make_annotations(files, format_advice, tidy_advice, style="")

--- a/tests/comments/test_comments.py
+++ b/tests/comments/test_comments.py
@@ -46,7 +46,7 @@ def test_post_feedback(
     )
     # add a non project file to tidy_advice to intentionally cover a log.debug()
     assert tidy_advice
-    tidy_advice[-1].append(
+    tidy_advice[-1].notes.append(
         TidyNotification(
             notification_line=(
                 "/usr/include/stdio.h",


### PR DESCRIPTION
- encapsulate list of `TidyNotification`s into a new `TidyAdvice` class (for stronger typing).
- change all use of clang-tidy diagnostic names (as plain text) into a hyperlink that points to clang-tidy docs; affects contents of `file-annotations`, `step-summary`, `thread-comments`.