### PR TITLE
bump the major versions of some GH actions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Draft your next Release notes as Pull Requests are merged into the default branch
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build wheel
         run: python3 -m pip wheel --no-deps -w dist .
       - name: Upload wheel as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cpp-linter_wheel
           path: ${{ github.workspace }}/dist/*.whl
@@ -53,7 +53,7 @@ jobs:
           python-version: ${{ matrix.py }}
 
       - name: download wheel artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cpp-linter_wheel
           path: dist
@@ -97,7 +97,7 @@ jobs:
         run: coverage run -m pytest
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-data-${{ runner.os }}-py${{ matrix.py }}-${{ matrix.version }}
           path: .coverage*
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ci-artifacts
 
@@ -127,7 +127,7 @@ jobs:
           coverage html
 
       - name: Upload comprehensive coverage HTML report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: htmlcov/


### PR DESCRIPTION
The idea is to satisfy the deprecation of actions that still use node.js v16.

Actions that are bumped here use node.js v20