### PR TITLE
bump codecov-action to v4

### DIFF
--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -134,9 +134,10 @@ jobs:
 
       - run: coverage report && coverage xml
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)


### PR DESCRIPTION
uses node.js v20 instead of deprecated node.js v16

also uses token in an env var as recommended by codecov docs