### PR TITLE
Auto update doc copyright year

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,7 +13,7 @@ jobs:
           python-version: 3.x
 
       - name: Install docs dependencies
-        run: pip install -r docs/requirements.txt -r requirements.txt
+        run: pip install -r docs/requirements.txt -e .
 
       - name: Build docs
         run: sphinx-build docs docs/_build/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,8 @@
 import sys
 import re
 from pathlib import Path
+import time
+from importlib.metadata import version as get_version
 from sphinx.application import Sphinx
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -15,9 +17,9 @@ from cpp_linter.cli import cli_arg_parser  # noqa: E402
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 project = "cpp-linter"
-copyright = "2022, 2bndy5"
+copyright = f"{time.localtime().tm_year}, 2bndy5"
 author = "2bndy5"
-release = "2.0.0"
+release = get_version("cpp-linter")
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,16 +3,12 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import sys
 import re
 from pathlib import Path
 import time
 from importlib.metadata import version as get_version
 from sphinx.application import Sphinx
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
-from cpp_linter.cli import cli_arg_parser  # noqa: E402
+from cpp_linter.cli import cli_arg_parser
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information


### PR DESCRIPTION
Based on suggestion in https://github.com/cpp-linter/cpp-linter/pull/70#issuecomment-1938295863, this updates the docs' copyright year dynamically at build time.

I also have the docs' version metadata synced with cpp-linter pkg version.