### PR TITLE
handle REST API rate limits and pagination

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-requests
+          - types-docutils
           - rich
           - pytest
           - meson

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,36 +13,22 @@ repos:
       - id: requirements-txt-fixer
       - id: mixed-line-ending
         args: ["--fix=lf"]
-  - repo: https://github.com/python/black
-    rev: '23.10.1'
-    hooks:
-      - id: black
-        args: ["--diff"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.287
+    rev: v0.2.2
     hooks:
+      # Run the linter.
       - id: ruff
-        types: [python]
-  - repo: local
-    # this is a "local" hook to run mypy (see https://pre-commit.com/#repository-local-hooks)
-    # because the mypy project doesn't seem to be compatible with pre-commit hooks
+      # Run the formatter.
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.8.0'
     hooks:
       - id: mypy
-        name: mypy
-        description: type checking with mypy tool
-        language: python
-        types: [python]
-        entry: mypy
-        exclude: "^(docs/|setup.py$)"
         additional_dependencies:
-         - mypy
-         - types-pyyaml
-         - types-requests
-         - rich
-         - requests
-         - pytest
-         - pyyaml
-         - meson
-         - requests-mock
-         - '.'
+          - types-requests
+          - rich
+          - pytest
+          - meson
+          - requests-mock
+          - '.'

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -11,6 +11,7 @@ from ..common_fs import FileObj
 NOTE_HEADER = re.compile(r"^(.+):(\d+):(\d+):\s(\w+):(.*)\[([a-zA-Z\d\-\.]+)\]$")
 FIXED_NOTE = re.compile(r"^.+:(\d+):\d+:\snote: FIX-IT applied suggested code changes$")
 
+
 class TidyNotification:
     """Create a object that decodes info from the clang-tidy output's initial line that
     details a specific notification.
@@ -168,7 +169,7 @@ def run_clang_tidy(
         extra_args = extra_args[0].split()
     for extra_arg in extra_args:
         arg = extra_arg.strip('"')
-        cmds.append(f'--extra-arg={arg}')
+        cmds.append(f"--extra-arg={arg}")
     if tidy_review:
         # clang-tidy overwrites the file contents when applying fixes.
         # create a cache of original contents

--- a/cpp_linter/loggers.py
+++ b/cpp_linter/loggers.py
@@ -47,8 +47,9 @@ def log_response_msg(response: Response):
     """Output the response buffer's message on a failed request."""
     if response.status_code >= 400:
         logger.error(
-            "response returned %d from %s with message: %s",
+            "response returned %d from %s %s with message: %s",
             response.status_code,
-            response.url,
+            response.request.method,
+            response.request.url,
             response.text,
         )

--- a/cpp_linter/loggers.py
+++ b/cpp_linter/loggers.py
@@ -43,12 +43,12 @@ def end_log_group() -> None:
     log_commander.fatal("::endgroup::")
 
 
-def log_response_msg(response_buffer: Response):
+def log_response_msg(response: Response):
     """Output the response buffer's message on a failed request."""
-    if response_buffer.status_code >= 400:
+    if response.status_code >= 400:
         logger.error(
             "response returned %d from %s with message: %s",
-            response_buffer.status_code,
-            response_buffer.url,
-            response_buffer.text,
+            response.status_code,
+            response.url,
+            response.text,
         )

--- a/cpp_linter/loggers.py
+++ b/cpp_linter/loggers.py
@@ -43,12 +43,8 @@ def end_log_group() -> None:
     log_commander.fatal("::endgroup::")
 
 
-def log_response_msg(response_buffer: Response) -> bool:
-    """Output the response buffer's message on a failed request.
-
-    :returns:
-        A bool describing if response's status code was less than 400.
-    """
+def log_response_msg(response_buffer: Response):
+    """Output the response buffer's message on a failed request."""
     if response_buffer.status_code >= 400:
         logger.error(
             "response returned %d from %s with message: %s",
@@ -56,5 +52,3 @@ def log_response_msg(response_buffer: Response) -> bool:
             response_buffer.url,
             response_buffer.text,
         )
-        return False
-    return True

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from pathlib import PurePath
 import requests
-from typing import Optional, Dict, List, Tuple
+from typing import Optional, Dict, List, Tuple, Any
 from ..common_fs import FileObj
 from ..clang_tools.clang_format import FormatAdvice
 from ..clang_tools.clang_tidy import TidyAdvice
@@ -18,6 +18,27 @@ COMMENT_MARKER = "<!-- cpp linter action -->\n"
 class RestApiClient(ABC):
     def __init__(self) -> None:
         self.session = requests.Session()
+
+    def api_request(
+        self,
+        url: str,
+        method: Optional[str] = None,
+        data: Optional[str] = None,
+        headers: Optional[Dict[str, Any]] = None,
+    ) -> Optional[requests.Response]:
+        """A helper function to streamline handling of HTTP requests' responses.
+
+        :param url: The  HTTP request URL.
+        :param method: The HTTP request method. The default value `None` means
+            "GET" if ``data`` is `None` else "POST"
+        :param data: The HTTP request payload data.
+        :param headers: The HTTP request headers to use. This can be used to override
+            the default headers used.
+
+        Returns:
+            A HTTP response body upon success, otherwise `None`.
+        """
+        raise NotImplementedError("Must be defined in the derivative")
 
     def set_exit_code(
         self,

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -25,6 +25,7 @@ class RestApiClient(ABC):
         method: Optional[str] = None,
         data: Optional[str] = None,
         headers: Optional[Dict[str, Any]] = None,
+        strict: bool = True,
     ) -> requests.Response:
         """A helper function to streamline handling of HTTP requests' responses.
 
@@ -34,6 +35,8 @@ class RestApiClient(ABC):
         :param data: The HTTP request payload data.
         :param headers: The HTTP request headers to use. This can be used to override
             the default headers used.
+        :param strict: If this is set `True`, then an `HTTPError` will be raised when
+            the HTTP request responds with a status code greater than or equal to 400.
 
         :returns:
             The HTTP request's response object.

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -25,7 +25,7 @@ class RestApiClient(ABC):
         method: Optional[str] = None,
         data: Optional[str] = None,
         headers: Optional[Dict[str, Any]] = None,
-    ) -> Optional[requests.Response]:
+    ) -> requests.Response:
         """A helper function to streamline handling of HTTP requests' responses.
 
         :param url: The  HTTP request URL.
@@ -35,8 +35,8 @@ class RestApiClient(ABC):
         :param headers: The HTTP request headers to use. This can be used to override
             the default headers used.
 
-        Returns:
-            A HTTP response body upon success, otherwise `None`.
+        :returns:
+            The HTTP request's response object.
         """
         raise NotImplementedError("Must be defined in the derivative")
 

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -338,7 +338,7 @@ class GithubApiClient(RestApiClient):
 
         :returns: If updating a comment, this will return the comment URL.
         """
-        logger.info("comments_url: %s", comments_url)
+        logger.debug("comments_url: %s", comments_url)
         comment_url: Optional[str] = None
         page = 1
         next_page: Optional[str] = comments_url + f"?page={page}&per_page=100"

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -19,7 +19,6 @@ from typing import Dict, List, Any, cast, Optional, Tuple, Union, Sequence
 
 from pygit2 import Patch  # type: ignore
 import requests
-from requests.structures import CaseInsensitiveDict
 from ..common_fs import FileObj, CACHE_PATH
 from ..clang_tools.clang_format import FormatAdvice, formalize_style_name
 from ..clang_tools.clang_tidy import TidyAdvice
@@ -57,6 +56,8 @@ class GithubApiClient(RestApiClient):
         self._rate_limit_remaining = -1  # -1 means unknown
         # a counter for avoiding secondary rate limits
         self._rate_limit_back_step = 0
+        # the rate limit reset time
+        self._rate_limit_reset: Optional[time.struct_time] = None
 
     def set_exit_code(
         self,
@@ -64,30 +65,23 @@ class GithubApiClient(RestApiClient):
         format_checks_failed: Optional[int] = None,
         tidy_checks_failed: Optional[int] = None,
     ):
-        try:
+        if "GITHUB_OUTPUT" in environ:
             with open(environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as env_file:
                 env_file.write(f"checks-failed={checks_failed}\n")
                 env_file.write(
                     f"clang-format-checks-failed={format_checks_failed or 0}\n"
                 )
                 env_file.write(f"clang-tidy-checks-failed={tidy_checks_failed or 0}\n")
-        except (KeyError, FileNotFoundError):  # pragma: no cover
-            # not executed on a github CI runner.
-            pass  # ignore this error when executed locally
         return super().set_exit_code(
             checks_failed, format_checks_failed, tidy_checks_failed
         )
 
-    @staticmethod
-    def _rate_limit_exceeded(
-        response_headers: Union[CaseInsensitiveDict, Dict[str, str]],
-    ):
+    def _rate_limit_exceeded(self):
         logger.error("RATE LIMIT EXCEEDED!")
-        if "x-ratelimit-reset" in response_headers:
-            reset_epoch = time.gmtime(int(response_headers["x-ratelimit-reset"]))
+        if self._rate_limit_reset is not None:
             logger.error(
                 "Github REST API rate limit resets on %s",
-                time.strftime("%d %B %Y %H:%M +0000", reset_epoch),
+                time.strftime("%d %B %Y %H:%M +0000", self._rate_limit_reset),
             )
         sys.exit(1)
 
@@ -99,7 +93,7 @@ class GithubApiClient(RestApiClient):
         headers: Optional[Dict[str, Any]] = None,
     ) -> requests.Response:
         if self._rate_limit_back_step >= 5 or self._rate_limit_remaining == 0:
-            self._rate_limit_exceeded({})
+            self._rate_limit_exceeded()
         response = self.session.request(
             method=method or ("GET" if data is None else "POST"),
             url=url,
@@ -109,6 +103,10 @@ class GithubApiClient(RestApiClient):
         self._rate_limit_remaining = int(
             response.headers.get("x-ratelimit-remaining", "-1")
         )
+        if "x-ratelimit-reset" in response.headers:
+            self._rate_limit_reset = time.gmtime(
+                int(response.headers["x-ratelimit-reset"])
+            )
         log_response_msg(response)
         if response.status_code in [403, 429]:  # rate limit exceeded
             # secondary rate limit handling
@@ -126,7 +124,8 @@ class GithubApiClient(RestApiClient):
                 return self.api_request(url, method=method, data=data, headers=headers)
             # primary rate limit handling
             if self._rate_limit_remaining == 0:
-                self._rate_limit_exceeded(response.headers)
+                self._rate_limit_exceeded()
+        response.raise_for_status()
         self._rate_limit_back_step = 0
         return response
 
@@ -151,11 +150,11 @@ class GithubApiClient(RestApiClient):
                     )
                 files_link += f"commits/{self.sha}"
             logger.info("Fetching files list from url: %s", files_link)
-            response_buffer = self.api_request(
+            response = self.api_request(
                 url=files_link, headers=self.make_headers(use_diff=True)
             )
             files = parse_diff(
-                response_buffer.text,
+                response.text,
                 extensions,
                 ignored,
                 not_ignored,
@@ -183,13 +182,14 @@ class GithubApiClient(RestApiClient):
                 logger.warning(
                     "Could not find %s! Did you checkout the repo?", file_name
                 )
-                raw_url = f"https://github.com/{self.repo}/raw/{self.sha}/"
+                raw_url = f"{self.api_url}/repos/{self.repo}/contents/"
                 raw_url += urllib.parse.quote(file.name, safe="")
+                raw_url += f"?ref={self.sha}"
                 logger.info("Downloading file from url: %s", raw_url)
-                response_buffer = self.api_request(url=raw_url)
+                response = self.api_request(url=raw_url)
                 # retain the repo's original structure
                 Path.mkdir(file_name.parent, parents=True, exist_ok=True)
-                file_name.write_text(response_buffer.text, encoding="utf-8")
+                file_name.write_bytes(response.content)
 
     def make_headers(self, use_diff: bool = False) -> Dict[str, str]:
         headers = {
@@ -324,15 +324,7 @@ class GithubApiClient(RestApiClient):
                 req_meth = "POST"
             payload = json.dumps({"body": comment})
             logger.debug("payload body:\n%s", payload)
-            response_buffer = self.api_request(
-                url=comments_url, method=req_meth, data=payload
-            )
-            if response_buffer.status_code < 400:
-                logger.info(
-                    "Got %d response from %sing comment",
-                    response_buffer.status_code,
-                    req_meth,
-                )
+            self.api_request(url=comments_url, method=req_meth, data=payload)
 
     def remove_bot_comments(self, comments_url: str, delete: bool) -> Optional[str]:
         """Traverse the list of comments made by a specific user
@@ -349,10 +341,11 @@ class GithubApiClient(RestApiClient):
         page = 1
         next_page: Optional[str] = comments_url + f"?page={page}&per_page=100"
         while next_page:
-            response_buffer = self.api_request(url=next_page)
-            if response_buffer.status_code >= 400:
-                return comment_url  # error getting comments for the thread; stop here
-            comments = cast(List[Dict[str, Any]], response_buffer.json())
+            response = self.api_request(url=next_page)
+            next_page = has_more_pages(response)
+            page += 1
+
+            comments = cast(List[Dict[str, Any]], response.json())
             if logger.level >= logging.DEBUG:
                 json_comments = Path(f"{CACHE_PATH}/comments-pg{page}.json")
                 json_comments.write_text(
@@ -375,17 +368,9 @@ class GithubApiClient(RestApiClient):
 
                         # use saved comment_url if not None else current comment url
                         url = comment_url or comment["url"]
-                        response_buffer = self.api_request(url=url, method="DELETE")
-                        if response_buffer.status_code < 400:
-                            logger.info(
-                                "Got %d from DELETE %s",
-                                response_buffer.status_code,
-                                url.lstrip(self.api_url),
-                            )
+                        self.api_request(url=url, method="DELETE")
                     if not delete:
                         comment_url = cast(str, comment["url"])
-            next_page = has_more_pages(response_buffer.headers)
-            page += 1
         return comment_url
 
     def post_review(
@@ -398,16 +383,14 @@ class GithubApiClient(RestApiClient):
         no_lgtm: bool,
     ):
         url = f"{self.api_url}/repos/{self.repo}/pulls/{self.event_payload['number']}"
-        response_buffer = self.api_request(url=url)
+        response = self.api_request(url=url)
         url += "/reviews"
-        is_draft = True
-        if response_buffer.status_code == 200:
-            pr_payload = response_buffer.json()
-            is_draft = cast(Dict[str, bool], pr_payload).get("draft", False)
-            is_open = cast(Dict[str, str], pr_payload).get("state", "open") == "open"
+        pr_info = response.json()
+        is_draft = cast(Dict[str, bool], pr_info).get("draft", False)
+        is_open = cast(Dict[str, str], pr_info).get("state", "open") == "open"
         if "GITHUB_TOKEN" not in environ:
             logger.error("A GITHUB_TOKEN env var is required to post review comments")
-            sys.exit(self.set_exit_code(1))
+            sys.exit(1)
         self._dismiss_stale_reviews(url)
         if is_draft or not is_open:  # is PR open and ready for review
             return  # don't post reviews
@@ -539,40 +522,36 @@ class GithubApiClient(RestApiClient):
         """Dismiss all reviews that were previously created by cpp-linter"""
         next_page: Optional[str] = url + "?page=1&per_page=100"
         while next_page:
-            response_buffer = self.api_request(url=next_page)
-            if response_buffer.status_code >= 400:
-                logger.error("Failed to poll existing reviews for dismissal")
-            else:
-                reviews: List[Dict[str, Any]] = response_buffer.json()
-                for review in reviews:
-                    if (
-                        "body" in review
-                        and cast(str, review["body"]).startswith(COMMENT_MARKER)
-                        and "state" in review
-                        and review["state"] not in ["PENDING", "DISMISSED"]
-                    ):
-                        assert "id" in review
-                        response_buffer = self.api_request(
-                            url=f"{url}/{review['id']}/dismissals",
-                            method="PUT",
-                            data=json.dumps(
-                                {"message": "outdated suggestion", "event": "DISMISS"}
-                            ),
-                        )
-            next_page = has_more_pages(response_buffer.headers)
+            response = self.api_request(url=next_page)
+            next_page = has_more_pages(response)
+
+            reviews: List[Dict[str, Any]] = response.json()
+            for review in reviews:
+                if (
+                    "body" in review
+                    and cast(str, review["body"]).startswith(COMMENT_MARKER)
+                    and "state" in review
+                    and review["state"] not in ["PENDING", "DISMISSED"]
+                ):
+                    assert "id" in review
+                    self.api_request(
+                        url=f"{url}/{review['id']}/dismissals",
+                        method="PUT",
+                        data=json.dumps(
+                            {"message": "outdated suggestion", "event": "DISMISS"}
+                        ),
+                    )
 
 
-def has_more_pages(headers: CaseInsensitiveDict) -> Optional[str]:
+def has_more_pages(response: requests.Response) -> Optional[str]:
     """A helper function to parse a HTTP request's response headers to determine if the
     previous REST API call is paginated.
 
-    :param headers: A HTTP response's headers.
+    :param response: A HTTP request's response.
 
     :returns: The URL of the next page if any, otherwise `None`.
     """
-    if "link" in headers:
-        links = cast(str, headers["link"]).split(", ")
-        for url, pos in [link.split("; ") for link in links]:
-            if pos.endswith('rel="next"'):
-                return url.lstrip("<").rstrip(">")
+    links = response.links
+    if "next" in links and "url" in links["next"]:
+        return links["next"]["url"]
     return None

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -92,6 +92,7 @@ class GithubApiClient(RestApiClient):
                 "Github REST API rate limit resets on %s",
                 time.strftime("%d %B %Y %H:%M +0000", reset_epoch),
             )
+        sys.exit(1)
 
     def api_request(
         self,
@@ -99,10 +100,9 @@ class GithubApiClient(RestApiClient):
         method: Optional[str] = None,
         data: Optional[str] = None,
         headers: Optional[Dict[str, Any]] = None,
-    ) -> Optional[requests.Response]:
+    ) -> requests.Response:
         if self._rate_limit_back_step > 5 or self._rate_limit_remaining == 0:
             self._rate_limit_exceeded({})
-            return None
         response = self.session.request(
             method=method or ("GET" if data is None else "POST"),
             url=url,
@@ -113,27 +113,23 @@ class GithubApiClient(RestApiClient):
             response.headers.get("x-ratelimit-remaining", "-1")
         )
         log_response_msg(response)
-        if response.status_code >= 400:
-            if response.status_code in [403, 429]:  # rate limit exceeded
-                # secondary rate limit handling
-                if "retry-after" in response.headers:
-                    wait_time = (
-                        float(cast(str, response.headers.get("retry-after")))
-                        * self._rate_limit_back_step
-                    )
-                    logger.warning(
-                        "SECONDARY RATE LIMIT HIT! Backing off for %f seconds",
-                        wait_time,
-                    )
-                    time.sleep(wait_time)
-                    self._rate_limit_back_step += 1
-                    return self.api_request(
-                        url, method=method, data=data, headers=headers
-                    )
-                # primary rate limit handling
-                if self._rate_limit_remaining == 0:
-                    self._rate_limit_exceeded(response.headers)
-            return None
+        if response.status_code in [403, 429]:  # rate limit exceeded
+            # secondary rate limit handling
+            if "retry-after" in response.headers:
+                wait_time = (
+                    float(cast(str, response.headers.get("retry-after")))
+                    * self._rate_limit_back_step
+                )
+                logger.warning(
+                    "SECONDARY RATE LIMIT HIT! Backing off for %f seconds",
+                    wait_time,
+                )
+                time.sleep(wait_time)
+                self._rate_limit_back_step += 1
+                return self.api_request(url, method=method, data=data, headers=headers)
+            # primary rate limit handling
+            if self._rate_limit_remaining == 0:
+                self._rate_limit_exceeded(response.headers)
         self._rate_limit_back_step = 0
         return response
 
@@ -161,16 +157,12 @@ class GithubApiClient(RestApiClient):
             response_buffer = self.api_request(
                 url=files_link, headers=self.make_headers(use_diff=True)
             )
-            files = (
-                []
-                if response_buffer is None
-                else parse_diff(
-                    response_buffer.text,
-                    extensions,
-                    ignored,
-                    not_ignored,
-                    lines_changed_only,
-                )
+            files = parse_diff(
+                response_buffer.text,
+                extensions,
+                ignored,
+                not_ignored,
+                lines_changed_only,
             )
         else:
             files = parse_diff(
@@ -200,10 +192,7 @@ class GithubApiClient(RestApiClient):
                 response_buffer = self.api_request(url=raw_url)
                 # retain the repo's original structure
                 Path.mkdir(file_name.parent, parents=True, exist_ok=True)
-                file_name.write_text(
-                    "" if response_buffer is None else response_buffer.text,
-                    encoding="utf-8",
-                )
+                file_name.write_text(response_buffer.text, encoding="utf-8")
 
     def make_headers(self, use_diff: bool = False) -> Dict[str, str]:
         headers = {
@@ -265,12 +254,12 @@ class GithubApiClient(RestApiClient):
         if self.event_name == "pull_request":
             comments_url = base_url + f'issues/{self.event_payload["number"]}'
             response_buffer = self.api_request(comments_url)
-            if response_buffer is not None:
+            if response_buffer.status_code == 200:
                 count = cast(int, response_buffer.json()["comments"])
         else:
             comments_url = base_url + f"commits/{self.sha}"
             response_buffer = self.api_request(comments_url)
-            if response_buffer is not None:
+            if response_buffer.status_code == 200:
                 count = cast(int, response_buffer.json()["commit"]["comment_count"])
         return count, comments_url + "/comments"
 
@@ -358,7 +347,7 @@ class GithubApiClient(RestApiClient):
             response_buffer = self.api_request(
                 comments_url, method=req_meth, data=payload
             )
-            if response_buffer is not None:
+            if response_buffer.status_code < 400:
                 logger.info(
                     "Got %d response from %sing comment",
                     response_buffer.status_code,
@@ -383,7 +372,7 @@ class GithubApiClient(RestApiClient):
         comment_url: Optional[str] = None
         while count:
             response_buffer = self.api_request(comments_url + f"?page={page}")
-            if response_buffer is None:
+            if response_buffer.status_code >= 400:
                 return comment_url  # error getting comments for the thread; stop here
             comments = cast(List[Dict[str, Any]], response_buffer.json())
             if logger.level >= logging.DEBUG:
@@ -411,7 +400,7 @@ class GithubApiClient(RestApiClient):
                         # use saved comment_url if not None else current comment url
                         url = comment_url or comment["url"]
                         response_buffer = self.api_request(url, method="DELETE")
-                        if response_buffer is not None:
+                        if response_buffer.status_code < 400:
                             logger.info(
                                 "Got %d from DELETE %s",
                                 response_buffer.status_code,
@@ -434,7 +423,7 @@ class GithubApiClient(RestApiClient):
         response_buffer = self.api_request(url)
         url += "/reviews"
         is_draft = True
-        if response_buffer is not None:
+        if response_buffer.status_code == 200:
             pr_payload = response_buffer.json()
             is_draft = cast(Dict[str, bool], pr_payload).get("draft", False)
             is_open = cast(Dict[str, str], pr_payload).get("state", "open") == "open"
@@ -484,7 +473,7 @@ class GithubApiClient(RestApiClient):
             "event": event,
             "comments": payload_comments,
         }
-        response_buffer = self.api_request(url, data=json.dumps(payload))
+        self.api_request(url, data=json.dumps(payload))
 
     @staticmethod
     def create_review_comments(
@@ -571,7 +560,7 @@ class GithubApiClient(RestApiClient):
     def _dismiss_stale_reviews(self, url: str):
         """Dismiss all reviews that were previously created by cpp-linter"""
         response_buffer = self.api_request(url)
-        if response_buffer is None:
+        if response_buffer.status_code >= 400:
             logger.error("Failed to poll existing reviews for dismissal")
         else:
             reviews: List[Dict[str, Any]] = response_buffer.json()

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -91,6 +91,7 @@ class GithubApiClient(RestApiClient):
         method: Optional[str] = None,
         data: Optional[str] = None,
         headers: Optional[Dict[str, Any]] = None,
+        strict: bool = True,
     ) -> requests.Response:
         if self._rate_limit_back_step >= 5 or self._rate_limit_remaining == 0:
             self._rate_limit_exceeded()
@@ -125,7 +126,8 @@ class GithubApiClient(RestApiClient):
             # primary rate limit handling
             if self._rate_limit_remaining == 0:
                 self._rate_limit_exceeded()
-        response.raise_for_status()
+        if strict:
+            response.raise_for_status()
         self._rate_limit_back_step = 0
         return response
 
@@ -368,7 +370,7 @@ class GithubApiClient(RestApiClient):
 
                         # use saved comment_url if not None else current comment url
                         url = comment_url or comment["url"]
-                        self.api_request(url=url, method="DELETE")
+                        self.api_request(url=url, method="DELETE", strict=False)
                     if not delete:
                         comment_url = cast(str, comment["url"])
         return comment_url
@@ -434,7 +436,7 @@ class GithubApiClient(RestApiClient):
             "event": event,
             "comments": payload_comments,
         }
-        self.api_request(url=url, data=json.dumps(payload))
+        self.api_request(url=url, data=json.dumps(payload), strict=False)
 
     @staticmethod
     def create_review_comments(
@@ -540,6 +542,7 @@ class GithubApiClient(RestApiClient):
                         data=json.dumps(
                             {"message": "outdated suggestion", "event": "DISMISS"}
                         ),
+                        strict=False,
                     )
 
 

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -19,6 +19,7 @@ from typing import Dict, List, Any, cast, Optional, Tuple, Union, Sequence
 
 from pygit2 import Patch  # type: ignore
 import requests
+from requests.structures import CaseInsensitiveDict
 from ..common_fs import FileObj, CACHE_PATH
 from ..clang_tools.clang_format import FormatAdvice, formalize_style_name
 from ..clang_tools.clang_tidy import TidyAdvice
@@ -79,15 +80,11 @@ class GithubApiClient(RestApiClient):
 
     @staticmethod
     def _rate_limit_exceeded(
-        response_headers: Union[
-            requests.structures.CaseInsensitiveDict, Dict[str, Any]
-        ],
+        response_headers: Union[CaseInsensitiveDict, Dict[str, str]],
     ):
         logger.error("RATE LIMIT EXCEEDED!")
         if "x-ratelimit-reset" in response_headers:
-            reset_epoch = time.gmtime(
-                int(cast(str, response_headers.get("x-ratelimit-reset")))
-            )
+            reset_epoch = time.gmtime(int(response_headers["x-ratelimit-reset"]))
             logger.error(
                 "Github REST API rate limit resets on %s",
                 time.strftime("%d %B %Y %H:%M +0000", reset_epoch),
@@ -227,12 +224,13 @@ class GithubApiClient(RestApiClient):
 
             update_only = thread_comments == "update"
             is_lgtm = not checks_failed
-            base_url = f"{self.api_url}/repos/{self.repo}/"
-            count, comments_url = self._get_comment_count(base_url)
-            if count >= 0:
-                self.update_comment(
-                    comment, comments_url, count, no_lgtm, update_only, is_lgtm
-                )
+            comments_url = f"{self.api_url}/repos/{self.repo}/"
+            if self.event_name == "pull_request":
+                comments_url += f'issues/{self.event_payload["number"]}'
+            else:
+                comments_url += f"commits/{self.sha}"
+            comments_url += "/comments"
+            self.update_comment(comment, comments_url, no_lgtm, update_only, is_lgtm)
 
         if self.event_name == "pull_request" and (tidy_review or format_review):
             self.post_review(
@@ -246,22 +244,6 @@ class GithubApiClient(RestApiClient):
             with open(environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
                 summary.write(f"\n{comment}\n")
         self.set_exit_code(checks_failed, format_checks_failed, tidy_checks_failed)
-
-    def _get_comment_count(self, base_url: str) -> Tuple[int, str]:
-        """Gets the comment count for the current event. Returns a negative count if
-        failed. Also returns the comments_url for the current event."""
-        count = -1
-        if self.event_name == "pull_request":
-            comments_url = base_url + f'issues/{self.event_payload["number"]}'
-            response_buffer = self.api_request(url=comments_url)
-            if response_buffer.status_code == 200:
-                count = cast(int, response_buffer.json()["comments"])
-        else:
-            comments_url = base_url + f"commits/{self.sha}"
-            response_buffer = self.api_request(url=comments_url)
-            if response_buffer.status_code == 200:
-                count = cast(int, response_buffer.json()["commit"]["comment_count"])
-        return count, comments_url + "/comments"
 
     def make_annotations(
         self,
@@ -313,7 +295,6 @@ class GithubApiClient(RestApiClient):
         self,
         comment: str,
         comments_url: str,
-        count: int,
         no_lgtm: bool,
         update_only: bool,
         is_lgtm: bool,
@@ -324,9 +305,8 @@ class GithubApiClient(RestApiClient):
 
         :param comment: The Comment to post.
         :param comments_url: The URL used to fetch the comments.
-        :param count: The number of comments to traverse.
         :param no_lgtm: A flag to control if a "Looks Good To Me" comment should be
-            posted. If this is `False`, then an outdated bot comment will still be
+            posted. If this is `True`, then an outdated bot comment will still be
             deleted.
         :param update_only: A flag that describes if the outdated bot comment should
             only be updated (instead of replaced).
@@ -334,7 +314,7 @@ class GithubApiClient(RestApiClient):
             a "Looks Good To Me" comment.
         """
         comment_url = self.remove_bot_comments(
-            comments_url, count, delete=not update_only or (is_lgtm and no_lgtm)
+            comments_url, delete=not update_only or (is_lgtm and no_lgtm)
         )
         if (is_lgtm and not no_lgtm) or not is_lgtm:
             if comment_url is not None:
@@ -354,24 +334,22 @@ class GithubApiClient(RestApiClient):
                     req_meth,
                 )
 
-    def remove_bot_comments(
-        self, comments_url: str, count: int, delete: bool
-    ) -> Optional[str]:
+    def remove_bot_comments(self, comments_url: str, delete: bool) -> Optional[str]:
         """Traverse the list of comments made by a specific user
         and remove all.
 
         :param comments_url: The URL used to fetch the comments.
-        :param count: The number of comments to traverse.
         :param delete: A flag describing if first applicable bot comment should be
             deleted or not.
 
         :returns: If updating a comment, this will return the comment URL.
         """
         logger.info("comments_url: %s", comments_url)
-        page = 1
         comment_url: Optional[str] = None
-        while count:
-            response_buffer = self.api_request(url=comments_url + f"?page={page}")
+        page = 1
+        next_page: Optional[str] = comments_url + f"?page={page}&per_page=100"
+        while next_page:
+            response_buffer = self.api_request(url=next_page)
             if response_buffer.status_code >= 400:
                 return comment_url  # error getting comments for the thread; stop here
             comments = cast(List[Dict[str, Any]], response_buffer.json())
@@ -381,8 +359,6 @@ class GithubApiClient(RestApiClient):
                     json.dumps(comments, indent=2), encoding="utf-8"
                 )
 
-            page += 1
-            count -= len(comments)
             for comment in comments:
                 # only search for comments that begin with a specific html comment.
                 # the specific html comment is our action's name
@@ -408,6 +384,8 @@ class GithubApiClient(RestApiClient):
                             )
                     if not delete:
                         comment_url = cast(str, comment["url"])
+            next_page = has_more_pages(response_buffer.headers)
+            page += 1
         return comment_url
 
     def post_review(
@@ -559,23 +537,42 @@ class GithubApiClient(RestApiClient):
 
     def _dismiss_stale_reviews(self, url: str):
         """Dismiss all reviews that were previously created by cpp-linter"""
-        response_buffer = self.api_request(url=url)
-        if response_buffer.status_code >= 400:
-            logger.error("Failed to poll existing reviews for dismissal")
-        else:
-            reviews: List[Dict[str, Any]] = response_buffer.json()
-            for review in reviews:
-                if (
-                    "body" in review
-                    and cast(str, review["body"]).startswith(COMMENT_MARKER)
-                    and "state" in review
-                    and review["state"] not in ["PENDING", "DISMISSED"]
-                ):
-                    assert "id" in review
-                    response_buffer = self.api_request(
-                        url=f"{url}/{review['id']}/dismissals",
-                        method="PUT",
-                        data=json.dumps(
-                            {"message": "outdated suggestion", "event": "DISMISS"}
-                        ),
-                    )
+        next_page: Optional[str] = url + "?page=1&per_page=100"
+        while next_page:
+            response_buffer = self.api_request(url=next_page)
+            if response_buffer.status_code >= 400:
+                logger.error("Failed to poll existing reviews for dismissal")
+            else:
+                reviews: List[Dict[str, Any]] = response_buffer.json()
+                for review in reviews:
+                    if (
+                        "body" in review
+                        and cast(str, review["body"]).startswith(COMMENT_MARKER)
+                        and "state" in review
+                        and review["state"] not in ["PENDING", "DISMISSED"]
+                    ):
+                        assert "id" in review
+                        response_buffer = self.api_request(
+                            url=f"{url}/{review['id']}/dismissals",
+                            method="PUT",
+                            data=json.dumps(
+                                {"message": "outdated suggestion", "event": "DISMISS"}
+                            ),
+                        )
+            next_page = has_more_pages(response_buffer.headers)
+
+
+def has_more_pages(headers: CaseInsensitiveDict) -> Optional[str]:
+    """A helper function to parse a HTTP request's response headers to determine if the
+    previous REST API call is paginated.
+
+    :param headers: A HTTP response's headers.
+
+    :returns: The URL of the next page if any, otherwise `None`.
+    """
+    if "link" in headers:
+        links = cast(str, headers["link"]).split(", ")
+        for url, pos in [link.split("; ") for link in links]:
+            if pos.endswith('rel="next"'):
+                return url.lstrip("<").rstrip(">")
+    return None

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -98,7 +98,7 @@ class GithubApiClient(RestApiClient):
         data: Optional[str] = None,
         headers: Optional[Dict[str, Any]] = None,
     ) -> requests.Response:
-        if self._rate_limit_back_step > 5 or self._rate_limit_remaining == 0:
+        if self._rate_limit_back_step >= 5 or self._rate_limit_remaining == 0:
             self._rate_limit_exceeded({})
         response = self.session.request(
             method=method or ("GET" if data is None else "POST"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -240,6 +240,7 @@ def setup(app: Sphinx):
         if not aliases or arg.default == "==SUPPRESS==":
             continue
         doc += "\n.. std:option:: " + ", ".join(aliases) + "\n"
+        assert arg.help is not None
         help = arg.help[: arg.help.find("Defaults to")]
         for ver, names in REQUIRED_VERSIONS.items():
             if arg.dest in names:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,4 @@ pytest
 requests-mock
 rich
 ruff
-types-PyYAML
 types-requests

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-"""Bootstrapper for docker's ENTRYPOINT executable.
-
-Since using setup.py is no longer std convention,
+"""Since using setup.py is no longer std convention,
 all install information is located in pyproject.toml
 """
 

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -90,8 +90,12 @@ def prep_api_client(
     for file in cache_path.rglob("*.*"):
         adapter.register_uri(
             "GET",
-            f"/{repo}/raw/{commit}/" + urllib.parse.quote(file.as_posix(), safe=""),
-            text=file.read_text(encoding="utf-8"),
+            f"/repos/{repo}/contents/"
+            + urllib.parse.quote(
+                file.as_posix().replace(cache_path.as_posix() + "/", ""), safe=""
+            )
+            + f"?ref={commit}",
+            content=file.read_bytes(),
         )
 
     mock_protocol = "http+mock://"

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -486,4 +486,4 @@ def test_tidy_extra_args(caplog: pytest.LogCaptureFixture, user_input: List[str]
     if len(user_input) == 1 and " " in user_input[0]:
         user_input = user_input[0].split()
     for a in user_input:
-        assert f'--extra-arg={a}' in messages[0]
+        assert f"--extra-arg={a}" in messages[0]

--- a/tests/comments/test_comments.py
+++ b/tests/comments/test_comments.py
@@ -105,15 +105,23 @@ def test_post_feedback(
                 f"{base_url}issues/{TEST_PR}",
                 text=(cache_path / f"pr_{TEST_PR}.json").read_text(encoding="utf-8"),
             )
+            comments_url = f"{base_url}issues/{TEST_PR}/comments"
             for i in [1, 2]:
                 mock.get(
-                    f"{base_url}issues/{TEST_PR}/comments?page={i}",
+                    f"{comments_url}?page={i}&per_page=100",
                     text=(cache_path / f"pr_comments_pg{i}.json").read_text(
                         encoding="utf-8"
                     ),
                     # to trigger a logged error, we'll modify the response when
                     # fetching page 2 of old comments and thread-comments is true
                     status_code=404 if i == 2 and thread_comments == "true" else 200,
+                    headers=(
+                        {}
+                        if i == 2
+                        else {
+                            "link": f'<{comments_url}?page=2&per_page=100>; rel="next"'
+                        }
+                    ),
                 )
         else:
             # load mock responses for push event

--- a/tests/comments/test_comments.py
+++ b/tests/comments/test_comments.py
@@ -112,9 +112,6 @@ def test_post_feedback(
                     text=(cache_path / f"pr_comments_pg{i}.json").read_text(
                         encoding="utf-8"
                     ),
-                    # to trigger a logged error, we'll modify the response when
-                    # fetching page 2 of old comments and thread-comments is true
-                    status_code=404 if i == 2 and thread_comments == "true" else 200,
                     headers=(
                         {}
                         if i == 2

--- a/tests/reviews/test_pr_review.py
+++ b/tests/reviews/test_pr_review.py
@@ -118,10 +118,8 @@ def test_post_review(
         )
         reviews = (cache_path / "pr_reviews.json").read_text(encoding="utf-8")
         mock.get(
-            f"{base_url}/reviews",
+            f"{base_url}/reviews?page=1&per_page=100",
             text=reviews,
-            # to trigger a logged error, we'll modify the status code here
-            status_code=404 if tidy_review and not format_review else 200,
         )
         mock.get(
             f"{base_url}/comments",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -7,7 +7,6 @@ import shutil
 from typing import List, cast
 
 import pytest
-import requests
 import requests_mock
 
 from cpp_linter.common_fs import (
@@ -19,7 +18,6 @@ from cpp_linter.clang_tools import assemble_version_exec
 from cpp_linter.loggers import (
     logger,
     log_commander,
-    log_response_msg,
     start_log_group,
     end_log_group,
 )
@@ -62,19 +60,6 @@ def test_start_group(caplog: pytest.LogCaptureFixture):
     start_log_group("TEST")
     messages = caplog.messages
     assert "::group::TEST" in messages
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        ("https://github.com/orgs/cpp-linter/repositories"),
-        pytest.param(("https://github.com/cpp-linter/repo"), marks=pytest.mark.xfail),
-    ],
-)
-def test_response_logs(url: str):
-    """Test the log output for a requests.response buffer."""
-    response_buffer = requests.get(url)
-    assert log_response_msg(response_buffer)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -1,5 +1,3 @@
-import json
-from pathlib import Path
 import time
 from typing import Dict
 import requests_mock
@@ -7,12 +5,6 @@ import pytest
 
 from cpp_linter.rest_api.github_api import GithubApiClient
 
-DUMMY_RESPONSE = {
-    "message": "DUMMY response for rate limit violations",
-    "documentation_url": (
-        "https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api",
-    ),
-}
 TEST_REPO = "test-user/test-repo"
 TEST_SHA = "0123456789ABCDEF"
 BASE_HEADERS = {
@@ -25,22 +17,15 @@ BASE_HEADERS = {
     "response_headers",
     [
         {**BASE_HEADERS, "x-ratelimit-remaining": "0"},
-        {**BASE_HEADERS, "retry-after": "0.25"},
+        {**BASE_HEADERS, "retry-after": "0.1"},
     ],
     ids=["primary", "secondary"],
 )
 def test_post_feedback(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    response_headers: Dict[str, str],
+    monkeypatch: pytest.MonkeyPatch, response_headers: Dict[str, str]
 ):
-    """A mock test of posting comments and step summary"""
+    """A mock test for hitting Github REST API rate limits"""
     # patch env vars
-    event_payload = {"repository": {"private": False}}
-    event_payload_path = tmp_path / "event_payload.json"
-    event_payload_path.write_text(json.dumps(event_payload), encoding="utf-8")
-    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_payload_path))
-    monkeypatch.setenv("CI", "true")
     monkeypatch.setenv("GITHUB_TOKEN", "123456")
     monkeypatch.setenv("GITHUB_REPOSITORY", TEST_REPO)
     monkeypatch.setenv("GITHUB_SHA", TEST_SHA)
@@ -53,12 +38,10 @@ def test_post_feedback(
         url = f"{gh_client.api_url}/repos/{TEST_REPO}/commits/{TEST_SHA}"
 
         # load mock responses for push event
-        mock.get(
-            url,
-            status_code=403,
-            text=json.dumps(DUMMY_RESPONSE),
-            headers=response_headers,
-        )
+        mock.get(url, status_code=403, headers=response_headers)
 
-        response = gh_client.api_request(url)
-        assert response is None
+        # ensure function exits early
+        with pytest.raises(SystemExit) as exc:
+            gh_client.api_request(url)
+        assert exc.type == SystemExit
+        assert exc.value.code == 1

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -21,9 +21,7 @@ BASE_HEADERS = {
     ],
     ids=["primary", "secondary"],
 )
-def test_post_feedback(
-    monkeypatch: pytest.MonkeyPatch, response_headers: Dict[str, str]
-):
+def test_rate_limit(monkeypatch: pytest.MonkeyPatch, response_headers: Dict[str, str]):
     """A mock test for hitting Github REST API rate limits"""
     # patch env vars
     monkeypatch.setenv("GITHUB_TOKEN", "123456")

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+import time
+from typing import Dict
+import requests_mock
+import pytest
+
+from cpp_linter.rest_api.github_api import GithubApiClient
+
+DUMMY_RESPONSE = {
+    "message": "DUMMY response for rate limit violations",
+    "documentation_url": (
+        "https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api",
+    ),
+}
+TEST_REPO = "test-user/test-repo"
+TEST_SHA = "0123456789ABCDEF"
+BASE_HEADERS = {
+    "x-ratelimit-remaining": "1",
+    "x-ratelimit-reset": str(int(time.mktime(time.localtime(None)))),
+}
+
+
+@pytest.mark.parametrize(
+    "response_headers",
+    [
+        {**BASE_HEADERS, "x-ratelimit-remaining": "0"},
+        {**BASE_HEADERS, "retry-after": "0.25"},
+    ],
+    ids=["primary", "secondary"],
+)
+def test_post_feedback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    response_headers: Dict[str, str],
+):
+    """A mock test of posting comments and step summary"""
+    # patch env vars
+    event_payload = {"repository": {"private": False}}
+    event_payload_path = tmp_path / "event_payload.json"
+    event_payload_path.write_text(json.dumps(event_payload), encoding="utf-8")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_payload_path))
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("GITHUB_TOKEN", "123456")
+    monkeypatch.setenv("GITHUB_REPOSITORY", TEST_REPO)
+    monkeypatch.setenv("GITHUB_SHA", TEST_SHA)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", "")
+
+    gh_client = GithubApiClient()
+
+    with requests_mock.Mocker() as mock:
+        url = f"{gh_client.api_url}/repos/{TEST_REPO}/commits/{TEST_SHA}"
+
+        # load mock responses for push event
+        mock.get(
+            url,
+            status_code=403,
+            text=json.dumps(DUMMY_RESPONSE),
+            headers=response_headers,
+        )
+
+        response = gh_client.api_request(url)
+        assert response is None


### PR DESCRIPTION
- Implemented REST API rate limit avoidance as advised by [github REST API docs](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api).
- Implemented REST API pagination as advised by [github REST API docs](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api).

## pre-commit changes
- removed unnecessary dependencies needed to run mypy
- switch mypy hook to official mypy hook
- switch from using black to ruff for formatting

## Other changes
- make any critical HTTP requests that fail raise a `HTTPError` and removed some corresponding log output
- updated the module doc string in setup.py
- use Github REST API endpoint to download missing files (and keep their original encoding). Previously we were using raw URLs to download files, but that wasn't good for private repos because the `GITHUB_TOKEN` provided only applies to REST API calls.
- use `GITHUB_TOKEN` for all REST API calls (if provided)