### PR TITLE
re-enable thread-comments on private repos

### DIFF
--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -226,12 +226,6 @@ an old comment and post a new one if necessary.
     See `Authenticating with the GITHUB_TOKEN
     <https://docs.github.com/en/actions/reference/authentication-in-a-workflow>`_
 
-.. hint::
-    If run on a private repository, then this feature
-    is disabled because the GitHub REST API behaves
-    differently for thread comments on a private
-    repository.
-
 Defaults to ``%(default)s``.""",
 )
 cli_arg_parser.add_argument(

--- a/cpp_linter/common_fs.py
+++ b/cpp_linter/common_fs.py
@@ -223,16 +223,13 @@ def is_source_or_ignored(
 def list_source_files(
     extensions: List[str], ignored: List[str], not_ignored: List[str]
 ) -> List[FileObj]:
-    """Make a list of source files to be checked. The resulting list is stored in
-    :attr:`~cpp_linter.Globals.FILES`.
+    """Make a list of source files to be checked.
 
     :param extensions: A list of file extensions that should by attended.
     :param ignored: A list of paths to explicitly ignore.
     :param not_ignored: A list of paths to explicitly not ignore.
 
-    :returns:
-        True if there are files to check. False will invoke a early exit (in
-        `main()` when no files to be checked.
+    :returns: A list of `FileObj` objects.
     """
     start_log_group("Get list of specified source files")
 

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -9,6 +9,7 @@ designed around GitHub's REST API.
     - `github rest API reference for issues <https://docs.github.com/en/rest/issues>`_
 """
 import json
+import logging
 from os import environ
 from pathlib import Path
 import urllib.parse
@@ -312,8 +313,11 @@ class GithubApiClient(RestApiClient):
             if not log_response_msg(response_buffer):
                 return comment_url  # error getting comments for the thread; stop here
             comments = cast(List[Dict[str, Any]], response_buffer.json())
-            json_comments = Path(f"{CACHE_PATH}/comments-pg{page}.json")
-            json_comments.write_text(json.dumps(comments, indent=2), encoding="utf-8")
+            if logger.level >= logging.DEBUG:
+                json_comments = Path(f"{CACHE_PATH}/comments-pg{page}.json")
+                json_comments.write_text(
+                    json.dumps(comments, indent=2), encoding="utf-8"
+                )
 
             page += 1
             count -= len(comments)

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -154,12 +154,7 @@ class GithubApiClient(RestApiClient):
             files, format_advice, tidy_advice
         )
         checks_failed = format_checks_failed + tidy_checks_failed
-        thread_comments_allowed = True
-        if self.event_payload and "private" in self.event_payload["repository"]:
-            thread_comments_allowed = (
-                self.event_payload["repository"]["private"] is not True
-            )
-        if thread_comments != "false" and thread_comments_allowed:
+        if thread_comments != "false":
             if "GITHUB_TOKEN" not in environ:
                 logger.error("The GITHUB_TOKEN is required!")
                 sys.exit(self.set_exit_code(1))

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -131,7 +131,7 @@ class GithubApiClient(RestApiClient):
 
     def make_headers(self, use_diff: bool = False) -> Dict[str, str]:
         headers = {
-            "Accept": "application/vnd.github." + ("diff" if use_diff else "text+json"),
+            "Accept": "application/vnd.github." + ("diff" if use_diff else "raw+json"),
         }
         gh_token = environ.get("GITHUB_TOKEN", "")
         if gh_token:

--- a/tests/comments/test_comments.py
+++ b/tests/comments/test_comments.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from os import environ
 from pathlib import Path
 import requests_mock
@@ -8,6 +9,7 @@ from cpp_linter.rest_api.github_api import GithubApiClient
 from cpp_linter.clang_tools import capture_clang_tools_output
 from cpp_linter.clang_tools.clang_tidy import TidyNotification
 from cpp_linter.common_fs import list_source_files
+from cpp_linter.loggers import logger
 
 TEST_REPO = "cpp-linter/test-cpp-linter-action"
 TEST_PR = 22
@@ -38,6 +40,7 @@ TEST_SHA = "8d68756375e0483c7ac2b4d6bbbece420dbbb495"
 )
 def test_post_feedback(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
     event_name: str,
     thread_comments: str,
@@ -132,6 +135,9 @@ def test_post_feedback(
         mock.patch(f"{comment_url}{comment_id}")
         mock.post(f"{base_url}commits/{TEST_SHA}/comments")
         mock.post(f"{base_url}issues/{TEST_PR}/comments")
+
+        # to get debug files saved to test workspace folders: enable logger verbosity
+        caplog.set_level(logging.DEBUG, logger=logger.name)
 
         gh_client.post_feedback(
             files,


### PR DESCRIPTION
I took another swing at this. It turns out the media type used in [request headers needs to select `raw+json`](https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#list-issue-comments-for-a-repository). This way we can see the raw contents of comments for a PR.

I also disabled saving the list of comments to a json file when logging is not verbose. This should've been changed in #47 or in #49, but I must have missed it.
