### PR TITLE
truncate thread comment to max size allowed

### DIFF
--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -324,7 +324,7 @@ class GithubApiClient(RestApiClient):
                 req_meth = "PATCH"
             else:
                 req_meth = "POST"
-            payload = json.dumps({"body": comment})
+            payload = json.dumps({"body": comment[:65536]})
             logger.debug("payload body:\n%s", payload)
             self.api_request(url=comments_url, method=req_meth, data=payload)
 


### PR DESCRIPTION
resolves #89

This should avoid the error observed in #89.

## A secondary problem
The thread-comments text is the same string used in step-summary text. But step-summary is not limited to a certain number of characters because it is written to a file. Therefore, if I truncate the comment's text when it is created in `make_comment()`, then the step-summary text will show the same lack of data, even though it isn't limited to 65535 characters.

As an alternative, I've chosen to just truncate the `payload["body"]` when posting a thread-comment using the REST API call. However, thread-comments may become malformed markdown syntax if they are longer than 65535 characters.
For example:
```md
A very long comment body that exceeds 65535 characters in the next line.

</details>
```
could become malformed like so
```md
A very long comment body that exceeds 65535 characters in the next line.

</det
```

