### PR TITLE
conditionally create comment

### DIFF
--- a/cpp_linter/clang_tools/clang_format.py
+++ b/cpp_linter/clang_tools/clang_format.py
@@ -79,6 +79,15 @@ class FormatAdvice:
         )
 
 
+def tally_format_advice(files: List[FileObj], format_advice: List[FormatAdvice]) -> int:
+    """Returns the sum of clang-format errors"""
+    format_checks_failed = 0
+    for file_obj, advice in zip(files, format_advice):
+        if advice.replaced_lines:
+            format_checks_failed += 1
+    return format_checks_failed
+
+
 def formalize_style_name(style: str) -> str:
     if style.startswith("llvm") or style.startswith("gnu"):
         return style.upper()

--- a/cpp_linter/clang_tools/clang_format.py
+++ b/cpp_linter/clang_tools/clang_format.py
@@ -79,10 +79,10 @@ class FormatAdvice:
         )
 
 
-def tally_format_advice(files: List[FileObj], format_advice: List[FormatAdvice]) -> int:
+def tally_format_advice(format_advice: List[FormatAdvice]) -> int:
     """Returns the sum of clang-format errors"""
     format_checks_failed = 0
-    for file_obj, advice in zip(files, format_advice):
+    for advice in format_advice:
         if advice.replaced_lines:
             format_checks_failed += 1
     return format_checks_failed

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -110,6 +110,16 @@ class TidyAdvice:
         return diagnostics
 
 
+def tally_tidy_advice(files: List[FileObj], tidy_advice: List[TidyAdvice]) -> int:
+    """Returns the sum of clang-format errors"""
+    tidy_checks_failed = 0
+    for file_obj, concern in zip(files, tidy_advice):
+        for note in concern.notes:
+            if file_obj.name == note.filename:
+                tidy_checks_failed += 1
+    return tidy_checks_failed
+
+
 def run_clang_tidy(
     command: str,
     file_obj: FileObj,

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -117,6 +117,8 @@ def tally_tidy_advice(files: List[FileObj], tidy_advice: List[TidyAdvice]) -> in
         for note in concern.notes:
             if file_obj.name == note.filename:
                 tidy_checks_failed += 1
+            else:
+                logger.debug("%s != %s", file_obj.name, note.filename)
     return tidy_checks_failed
 
 

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -107,6 +107,9 @@ class RestApiClient(ABC):
             ``files``.
         :param tidy_advice: A list of clang-tidy advice parallel to the list of
             ``files``.
+        :param format_checks_failed: The amount of clang-format checks that have failed.
+        :param tidy_checks_failed: The amount of clang-tidy checks that have failed.
+        :param len_limit: The length limit of the comment generated.
 
         :Returns: The markdown comment as a `str`
         """

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -132,7 +132,7 @@ class RestApiClient(ABC):
                     files=files,
                     advice_fix=format_advice,
                     checks_failed=format_checks_failed,
-                    len_limit=adjust_limit(limit=len_limit, text=comment),
+                    len_limit=len_limit,
                 )
             if tidy_checks_failed:
                 comment += RestApiClient._make_tidy_comment(

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -200,8 +200,6 @@ class RestApiClient(ABC):
                         or len(comment) + len(closer) + len(tidy_comment) < len_limit
                     ):
                         comment += tidy_comment
-                else:
-                    logger.debug("%s != %s", file_obj.name, note.filename)
         return comment + closer
 
     def post_feedback(

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -220,9 +220,7 @@ class GithubApiClient(RestApiClient):
         tidy_review: bool,
         format_review: bool,
     ):
-        format_checks_failed = tally_format_advice(
-            files=files, format_advice=format_advice
-        )
+        format_checks_failed = tally_format_advice(format_advice=format_advice)
         tidy_checks_failed = tally_tidy_advice(files=files, tidy_advice=tidy_advice)
         checks_failed = format_checks_failed + tidy_checks_failed
         comment: Optional[str] = None

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -245,6 +245,12 @@ class GithubApiClient(RestApiClient):
                 style=style,
             )
 
+        self.set_exit_code(
+            checks_failed=checks_failed,
+            format_checks_failed=format_checks_failed,
+            tidy_checks_failed=tidy_checks_failed,
+        )
+
         if thread_comments != "false":
             if "GITHUB_TOKEN" not in environ:
                 logger.error("The GITHUB_TOKEN is required!")
@@ -285,11 +291,6 @@ class GithubApiClient(RestApiClient):
                 format_review=format_review,
                 no_lgtm=no_lgtm,
             )
-        self.set_exit_code(
-            checks_failed=checks_failed,
-            format_checks_failed=format_checks_failed,
-            tidy_checks_failed=tidy_checks_failed,
-        )
 
     def make_annotations(
         self,

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -227,15 +227,23 @@ class GithubApiClient(RestApiClient):
 
         if step_summary and "GITHUB_STEP_SUMMARY" in environ:
             comment = super().make_comment(
-                files,
-                format_advice,
-                tidy_advice,
-                format_checks_failed,
-                tidy_checks_failed,
+                files=files,
+                format_advice=format_advice,
+                tidy_advice=tidy_advice,
+                format_checks_failed=format_checks_failed,
+                tidy_checks_failed=tidy_checks_failed,
                 len_limit=None,
             )
             with open(environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
                 summary.write(f"\n{comment}\n")
+
+        if file_annotations:
+            self.make_annotations(
+                files=files,
+                format_advice=format_advice,
+                tidy_advice=tidy_advice,
+                style=style,
+            )
 
         if thread_comments != "false":
             if "GITHUB_TOKEN" not in environ:
@@ -244,11 +252,11 @@ class GithubApiClient(RestApiClient):
 
             if comment is None or len(comment) >= 65535:
                 comment = super().make_comment(
-                    files,
-                    format_advice,
-                    tidy_advice,
-                    format_checks_failed,
-                    tidy_checks_failed,
+                    files=files,
+                    format_advice=format_advice,
+                    tidy_advice=tidy_advice,
+                    format_checks_failed=format_checks_failed,
+                    tidy_checks_failed=tidy_checks_failed,
                     len_limit=65535,
                 )
 
@@ -260,16 +268,28 @@ class GithubApiClient(RestApiClient):
             else:
                 comments_url += f"commits/{self.sha}"
             comments_url += "/comments"
-            self.update_comment(comment, comments_url, no_lgtm, update_only, is_lgtm)
+            self.update_comment(
+                comment=comment,
+                comments_url=comments_url,
+                no_lgtm=no_lgtm,
+                update_only=update_only,
+                is_lgtm=is_lgtm,
+            )
 
         if self.event_name == "pull_request" and (tidy_review or format_review):
             self.post_review(
-                files, tidy_advice, format_advice, tidy_review, format_review, no_lgtm
+                files=files,
+                tidy_advice=tidy_advice,
+                format_advice=format_advice,
+                tidy_review=tidy_review,
+                format_review=format_review,
+                no_lgtm=no_lgtm,
             )
-
-        if file_annotations:
-            self.make_annotations(files, format_advice, tidy_advice, style)
-        self.set_exit_code(checks_failed, format_checks_failed, tidy_checks_failed)
+        self.set_exit_code(
+            checks_failed=checks_failed,
+            format_checks_failed=format_checks_failed,
+            tidy_checks_failed=tidy_checks_failed,
+        )
 
     def make_annotations(
         self,

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -21,8 +21,12 @@ from typing import Dict, List, Any, cast, Optional, Tuple, Union, Sequence
 from pygit2 import Patch  # type: ignore
 import requests
 from ..common_fs import FileObj, CACHE_PATH
-from ..clang_tools.clang_format import FormatAdvice, formalize_style_name
-from ..clang_tools.clang_tidy import TidyAdvice
+from ..clang_tools.clang_format import (
+    FormatAdvice,
+    formalize_style_name,
+    tally_format_advice,
+)
+from ..clang_tools.clang_tidy import TidyAdvice, tally_tidy_advice
 from ..loggers import start_log_group, logger, log_response_msg, log_commander
 from ..git import parse_diff, get_diff
 from . import RestApiClient, USER_OUTREACH, COMMENT_MARKER
@@ -216,14 +220,39 @@ class GithubApiClient(RestApiClient):
         tidy_review: bool,
         format_review: bool,
     ):
-        (comment, format_checks_failed, tidy_checks_failed) = super().make_comment(
-            files, format_advice, tidy_advice
+        format_checks_failed = tally_format_advice(
+            files=files, format_advice=format_advice
         )
+        tidy_checks_failed = tally_tidy_advice(files=files, tidy_advice=tidy_advice)
         checks_failed = format_checks_failed + tidy_checks_failed
+        comment: Optional[str] = None
+
+        if step_summary and "GITHUB_STEP_SUMMARY" in environ:
+            comment = super().make_comment(
+                files,
+                format_advice,
+                tidy_advice,
+                format_checks_failed,
+                tidy_checks_failed,
+                len_limit=None,
+            )
+            with open(environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+                summary.write(f"\n{comment}\n")
+
         if thread_comments != "false":
             if "GITHUB_TOKEN" not in environ:
                 logger.error("The GITHUB_TOKEN is required!")
                 sys.exit(self.set_exit_code(1))
+
+            if comment is None or len(comment) >= 65535:
+                comment = super().make_comment(
+                    files,
+                    format_advice,
+                    tidy_advice,
+                    format_checks_failed,
+                    tidy_checks_failed,
+                    len_limit=65535,
+                )
 
             update_only = thread_comments == "update"
             is_lgtm = not checks_failed
@@ -242,10 +271,6 @@ class GithubApiClient(RestApiClient):
 
         if file_annotations:
             self.make_annotations(files, format_advice, tidy_advice, style)
-
-        if step_summary and "GITHUB_STEP_SUMMARY" in environ:
-            with open(environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
-                summary.write(f"\n{comment}\n")
         self.set_exit_code(checks_failed, format_checks_failed, tidy_checks_failed)
 
     def make_annotations(

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -254,7 +254,7 @@ class GithubApiClient(RestApiClient):
         if thread_comments != "false":
             if "GITHUB_TOKEN" not in environ:
                 logger.error("The GITHUB_TOKEN is required!")
-                sys.exit(self.set_exit_code(1))
+                sys.exit(1)
 
             if comment is None or len(comment) >= 65535:
                 comment = super().make_comment(

--- a/tests/capture_tools_output/test_database_path.py
+++ b/tests/capture_tools_output/test_database_path.py
@@ -115,7 +115,8 @@ def test_ninja_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
                 found_project_file = True
     if not found_project_file:  # pragma: no cover
         pytest.fail("no project files raised concerns with clang-tidy")
-    format_checks_failed = tally_format_advice(files=files, format_advice=format_advice)
+
+    format_checks_failed = tally_format_advice(format_advice=format_advice)
     tidy_checks_failed = tally_tidy_advice(files=files, tidy_advice=tidy_advice)
     comment = GithubApiClient.make_comment(
         files=files,

--- a/tests/capture_tools_output/test_database_path.py
+++ b/tests/capture_tools_output/test_database_path.py
@@ -12,6 +12,8 @@ from cpp_linter.loggers import logger
 from cpp_linter.common_fs import FileObj, CACHE_PATH
 from cpp_linter.rest_api.github_api import GithubApiClient
 from cpp_linter.clang_tools import capture_clang_tools_output
+from cpp_linter.clang_tools.clang_format import tally_format_advice
+from cpp_linter.clang_tools.clang_tidy import tally_tidy_advice
 from mesonbuild.mesonmain import main as meson  # type: ignore
 
 CLANG_TIDY_COMMAND = re.compile(r'clang-tidy[^\s]*\s(.*)"')
@@ -91,7 +93,6 @@ def test_ninja_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
 
     logger.setLevel(logging.DEBUG)
     files = [FileObj("demo.cpp")]
-    gh_client = GithubApiClient()
 
     # run clang-tidy and verify paths of project files were matched with database paths
     (format_advice, tidy_advice) = capture_clang_tools_output(
@@ -114,9 +115,16 @@ def test_ninja_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
                 found_project_file = True
     if not found_project_file:  # pragma: no cover
         pytest.fail("no project files raised concerns with clang-tidy")
-    (comment, format_checks_failed, tidy_checks_failed) = gh_client.make_comment(
-        files, format_advice, tidy_advice
+    format_checks_failed = tally_format_advice(files=files, format_advice=format_advice)
+    tidy_checks_failed = tally_tidy_advice(files=files, tidy_advice=tidy_advice)
+    comment = GithubApiClient.make_comment(
+        files=files,
+        format_advice=format_advice,
+        tidy_advice=tidy_advice,
+        tidy_checks_failed=tidy_checks_failed,
+        format_checks_failed=format_checks_failed,
     )
+
     assert tidy_checks_failed
     assert not format_checks_failed
 

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -65,7 +65,7 @@ def make_comment(
     format_advice: List[FormatAdvice],
     tidy_advice: List[TidyAdvice],
 ):
-    format_checks_failed = tally_format_advice(files=files, format_advice=format_advice)
+    format_checks_failed = tally_format_advice(format_advice=format_advice)
     tidy_checks_failed = tally_tidy_advice(files=files, tidy_advice=tidy_advice)
     comment = GithubApiClient.make_comment(
         files=files,

--- a/tests/test_comment_length.py
+++ b/tests/test_comment_length.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+from cpp_linter.rest_api.github_api import GithubApiClient
+from cpp_linter.rest_api import USER_OUTREACH
+from cpp_linter.clang_tools.clang_format import FormatAdvice, FormatReplacementLine
+from cpp_linter.common_fs import FileObj
+
+
+def test_comment_length_limit(tmp_path: Path):
+    """Ensure comment length does not exceed specified limit for thread-comments but is
+    unhindered for step-summary"""
+    file_name = "tests/demo/demo.cpp"
+    abs_limit = 65535
+    format_checks_failed = 3000
+    files = [FileObj(file_name)] * format_checks_failed
+    dummy_advice = FormatAdvice(file_name)
+    dummy_advice.replaced_lines = [FormatReplacementLine(line_numb=1)]
+    format_advice = [dummy_advice] * format_checks_failed
+    thread_comment = GithubApiClient.make_comment(
+        files=files,
+        format_advice=format_advice,
+        tidy_advice=[],
+        format_checks_failed=format_checks_failed,
+        tidy_checks_failed=0,
+        len_limit=abs_limit,
+    )
+    assert len(thread_comment) < abs_limit
+    assert thread_comment.endswith(USER_OUTREACH)
+    step_summary = GithubApiClient.make_comment(
+        files=files,
+        format_advice=format_advice,
+        tidy_advice=[],
+        format_checks_failed=format_checks_failed,
+        tidy_checks_failed=0,
+        len_limit=None,
+    )
+    assert len(step_summary) != len(thread_comment)
+    assert step_summary.endswith(USER_OUTREACH)
+
+    # output each in test dir for visual inspection
+    # use open() because Path.write_text() added `new_line` param in python v3.10
+    with open(
+        str(tmp_path / "thread_comment.md"), mode="w", encoding="utf-8", newline="\n"
+    ) as f_out:
+        f_out.write(thread_comment)
+    with open(
+        str(tmp_path / "step_summary.md"), mode="w", encoding="utf-8", newline="\n"
+    ) as f_out:
+        f_out.write(step_summary)


### PR DESCRIPTION
This better satisfies the maximum comment length imposed by GitHub while leaving the step summary length unhindered.

An added benefit here is that we only create a comment when it is needed. Previously, we were creating a comment to also get a tally of checks failed.

resolves #89 