### PR TITLE
perf: use io.StringIO instead tempdir/tempfile

### DIFF
--- a/cpp_linter/clang_tools/__init__.py
+++ b/cpp_linter/clang_tools/__init__.py
@@ -154,10 +154,10 @@ def capture_clang_tools_output(
         format_advice_map: Dict[str, Optional[FormatAdvice]] = {}
         tidy_notes_map: Dict[str, Optional[TidyAdvice]] = {}
         for future in as_completed(futures):
-            file, log, note, advice = future.result()
+            file, logs, note, advice = future.result()
 
             start_log_group(f"Performing checkup on {file}")
-            sys.stdout.write(log)
+            sys.stdout.write(logs)
             end_log_group()
 
             format_advice_map[file] = advice

--- a/cpp_linter/clang_tools/__init__.py
+++ b/cpp_linter/clang_tools/__init__.py
@@ -3,13 +3,12 @@ import json
 from pathlib import Path, PurePath
 import subprocess
 import sys
-from tempfile import TemporaryDirectory
 from textwrap import indent
 from typing import Optional, List, Dict, Tuple
 import shutil
 
 from ..common_fs import FileObj
-from ..loggers import start_log_group, end_log_group, worker_log_file_init, logger
+from ..loggers import start_log_group, end_log_group, worker_log_init, logger
 from .clang_tidy import run_clang_tidy, TidyAdvice
 from .clang_format import run_clang_format, FormatAdvice
 
@@ -36,7 +35,6 @@ def assemble_version_exec(tool_name: str, specified_version: str) -> Optional[st
 
 def _run_on_single_file(
     file: FileObj,
-    temp_dir: str,
     log_lvl: int,
     tidy_cmd,
     checks,
@@ -49,7 +47,7 @@ def _run_on_single_file(
     style,
     format_review,
 ):
-    log_file = worker_log_file_init(temp_dir, log_lvl)
+    log_stream = worker_log_init(log_lvl)
 
     tidy_note = None
     if tidy_cmd is not None:
@@ -70,7 +68,7 @@ def _run_on_single_file(
             format_cmd, file, style, lines_changed_only, format_review
         )
 
-    return file.name, log_file, tidy_note, format_advice
+    return file.name, log_stream.getvalue(), tidy_note, format_advice
 
 
 def capture_clang_tools_output(
@@ -131,13 +129,12 @@ def capture_clang_tools_output(
         if db_path.exists():
             db_json = json.loads(db_path.read_text(encoding="utf-8"))
 
-    with TemporaryDirectory() as temp_dir, ProcessPoolExecutor(num_workers) as executor:
+    with ProcessPoolExecutor(num_workers) as executor:
         log_lvl = logger.getEffectiveLevel()
         futures = [
             executor.submit(
                 _run_on_single_file,
                 file,
-                temp_dir=temp_dir,
                 log_lvl=log_lvl,
                 tidy_cmd=tidy_cmd,
                 checks=checks,
@@ -157,10 +154,10 @@ def capture_clang_tools_output(
         format_advice_map: Dict[str, Optional[FormatAdvice]] = {}
         tidy_notes_map: Dict[str, Optional[TidyAdvice]] = {}
         for future in as_completed(futures):
-            file, log_file, note, advice = future.result()
+            file, log, note, advice = future.result()
 
             start_log_group(f"Performing checkup on {file}")
-            sys.stdout.write(Path(log_file).read_text())
+            sys.stdout.write(log)
             end_log_group()
 
             format_advice_map[file] = advice

--- a/cpp_linter/loggers.py
+++ b/cpp_linter/loggers.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from tempfile import NamedTemporaryFile
+import io
 
 from requests import Response
 
@@ -57,8 +57,8 @@ def log_response_msg(response: Response):
         )
 
 
-def worker_log_file_init(temp_dir: str, log_lvl: int):
-    log_file = NamedTemporaryFile("w", dir=temp_dir, delete=False)
+def worker_log_init(log_lvl: int):
+    log_stream = io.StringIO()
 
     logger.handlers.clear()
     logger.propagate = False
@@ -68,11 +68,11 @@ def worker_log_file_init(temp_dir: str, log_lvl: int):
         FOUND_RICH_LIB and "CPP_LINTER_PYTEST_NO_RICH" not in os.environ
     ):  # pragma: no cover
         console = get_console()
-        console.file = log_file
+        console.file = log_stream
         handler = RichHandler(show_time=False, console=console)
         handler.setFormatter(logging.Formatter("%(name)s: %(message)s"))
     else:
-        handler = logging.StreamHandler(log_file)
+        handler = logging.StreamHandler(log_stream)
         handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
     logger.addHandler(handler)
     # Windows does not copy log level to subprocess.
@@ -82,8 +82,8 @@ def worker_log_file_init(temp_dir: str, log_lvl: int):
     ## uncomment the following if log_commander is needed in isolated threads
     # log_commander.handlers.clear()
     # log_commander.propagate = False
-    # console_handler = logging.StreamHandler(log_file)
+    # console_handler = logging.StreamHandler(log_stream)
     # console_handler.setFormatter(logging.Formatter("%(message)s"))
     # log_commander.addHandler(console_handler)
 
-    return log_file.name
+    return log_stream


### PR DESCRIPTION
This is a follow-up PR of #92.

In the previous PR review https://github.com/cpp-linter/cpp-linter/pull/92#discussion_r1532181842 @2bndy5 suggested:

> Can we avoid caching to a temp file? I raised some concern about this approach in [cpp-linter#73](https://github.com/orgs/cpp-linter/discussions/73#discussioncomment-8486098) as well (about cost in speed).
> Could we use [`io.StringIO` stream](https://docs.python.org/3/library/io.html#text-i-o) instead?

In that version, [multiprocessing.Pool.imap() was used](https://github.com/jnooree/cpp-linter/blob/5fefb726a6246cf00ab72f9045d9cea00d2e6163/cpp_linter/clang_tools/__init__.py#L139-L140) for parallel processing, and it [blocks](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.imap) until all of the results are made available (if I'm not misunderstood). The behavior might cause memory problems on repositories with many files and warnings.

After, I decided to switch to the async version in 4e029a317fe51a2399cd6519edd11422a8eb5448 by using [concurrent.futures.as_completed](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.as_completed), which returns the logs as each work is completed (hence its name). Now that the logs are immediately printed after the subprocess is done processing a file and logs for a single file would not overflow memory in most projects, I think it is safe to use `io.StringIO` for better performance (as with the original suggestion).