### PR TITLE
inline badges in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,21 +1,23 @@
 C/C++ Linting Package
 =====================
 
-.. image:: https://img.shields.io/github/v/release/cpp-linter/cpp-linter
+.. |latest-version| image:: https://img.shields.io/github/v/release/cpp-linter/cpp-linter
     :alt: Latest Version
     :target: https://github.com/cpp-linter/cpp-linter/releases
-.. image:: https://img.shields.io/github/license/cpp-linter/cpp-linter?label=license&logo=github
+.. |license-badge| image:: https://img.shields.io/github/license/cpp-linter/cpp-linter?label=license&logo=github
     :alt: License
     :target: https://github.com/cpp-linter/cpp-linter/blob/main/LICENSE
-.. image:: https://codecov.io/gh/cpp-linter/cpp-linter/branch/main/graph/badge.svg?token=0814O9WHQU
+.. |codecov-badge| image:: https://codecov.io/gh/cpp-linter/cpp-linter/branch/main/graph/badge.svg?token=0814O9WHQU
     :alt: CodeCov
     :target: https://codecov.io/gh/cpp-linter/cpp-linter
-.. image:: https://github.com/cpp-linter/cpp-linter/actions/workflows/build-docs.yml/badge.svg
+.. |doc-badge| image:: https://github.com/cpp-linter/cpp-linter/actions/workflows/build-docs.yml/badge.svg
     :alt: Docs
     :target: https://cpp-linter.github.io/cpp-linter
-.. image:: https://img.shields.io/pypi/dw/cpp-linter?color=dark-green&label=PyPI%20Downloads&logo=python&logoColor=white
+.. |pypi-badge| image:: https://img.shields.io/pypi/dw/cpp-linter?color=dark-green&label=PyPI%20Downloads&logo=python&logoColor=white
     :target: https://pepy.tech/project/cpp-linter
     :alt: PyPI - Downloads
+
+|latest-version| |license-badge| |codecov-badge| |doc-badge| |pypi-badge|
 
 A Python package for linting C/C++ code with clang-tidy and/or clang-format to collect feedback provided in the form of thread comments and/or file annotations.
 


### PR DESCRIPTION
Uses RST substitution to put README badges in 1 line.

ref cpp-linter/cpp-linter#95