### PR TITLE
Glob ignores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,6 @@ repos:
           - types-docutils
           - rich
           - pytest
-          - meson
           - requests-mock
           - '.'
   - repo: https://github.com/codespell-project/codespell

--- a/cpp_linter/__init__.py
+++ b/cpp_linter/__init__.py
@@ -41,9 +41,7 @@ def main():
     start_log_group("Get list of specified source files")
     if args.files_changed_only:
         files = rest_api_client.get_list_of_changed_files(
-            extensions=args.extensions,
-            ignored=global_file_filter.ignored,
-            not_ignored=global_file_filter.not_ignored,
+            file_filter=global_file_filter,
             lines_changed_only=args.lines_changed_only,
         )
         rest_api_client.verify_files_are_present(files)
@@ -54,9 +52,7 @@ def main():
         if is_pr_event and (args.tidy_review or args.format_review):
             # get file changes from diff
             git_changes = rest_api_client.get_list_of_changed_files(
-                extensions=args.extensions,
-                ignored=global_file_filter.ignored,
-                not_ignored=global_file_filter.not_ignored,
+                file_filter=global_file_filter,
                 lines_changed_only=0,  # prevent filtering out unchanged files
             )
             # merge info from git changes into list of all files
@@ -87,6 +83,9 @@ def main():
         tidy_review=is_pr_event and args.tidy_review,
         format_review=is_pr_event and args.format_review,
         num_workers=args.jobs,
+        extensions=args.extensions,
+        tidy_ignore=args.ignore_tidy,
+        format_ignore=args.ignore_format,
     )
 
     start_log_group("Posting comment(s)")

--- a/cpp_linter/__init__.py
+++ b/cpp_linter/__init__.py
@@ -7,7 +7,7 @@ from .common_fs import CACHE_PATH
 from .common_fs.file_filter import FileFilter
 from .loggers import start_log_group, end_log_group, logger
 from .clang_tools import capture_clang_tools_output
-from .cli import cli_arg_parser, Args
+from .cli import get_cli_parser, Args
 from .rest_api.github_api import GithubApiClient
 
 
@@ -15,7 +15,7 @@ def main():
     """The main script."""
 
     # The parsed CLI args
-    args = cli_arg_parser.parse_args(namespace=Args())
+    args = get_cli_parser().parse_args(namespace=Args())
 
     #  force files-changed-only to reflect value of lines-changed-only
     if args.lines_changed_only:

--- a/cpp_linter/__init__.py
+++ b/cpp_linter/__init__.py
@@ -75,15 +75,10 @@ def main():
         )
     end_log_group()
 
-    (format_advice, tidy_advice) = capture_clang_tools_output(files=files, args=args)
+    capture_clang_tools_output(files=files, args=args)
 
     start_log_group("Posting comment(s)")
-    rest_api_client.post_feedback(
-        files=files,
-        format_advice=format_advice,
-        tidy_advice=tidy_advice,
-        args=args,
-    )
+    rest_api_client.post_feedback(files=files, args=args)
     end_log_group()
 
 

--- a/cpp_linter/clang_tools/clang_format.py
+++ b/cpp_linter/clang_tools/clang_format.py
@@ -79,11 +79,13 @@ class FormatAdvice:
         )
 
 
-def tally_format_advice(format_advice: List[FormatAdvice]) -> int:
+def tally_format_advice(files: List[FileObj]) -> int:
     """Returns the sum of clang-format errors"""
     format_checks_failed = 0
-    for advice in format_advice:
-        if advice.replaced_lines:
+    for file_obj in files:
+        if not file_obj.format_advice:
+            continue
+        if file_obj.format_advice.replaced_lines:
             format_checks_failed += 1
     return format_checks_failed
 

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -110,11 +110,13 @@ class TidyAdvice:
         return diagnostics
 
 
-def tally_tidy_advice(files: List[FileObj], tidy_advice: List[TidyAdvice]) -> int:
+def tally_tidy_advice(files: List[FileObj]) -> int:
     """Returns the sum of clang-format errors"""
     tidy_checks_failed = 0
-    for file_obj, concern in zip(files, tidy_advice):
-        for note in concern.notes:
+    for file_obj in files:
+        if not file_obj.tidy_advice:
+            continue
+        for note in file_obj.tidy_advice.notes:
             if file_obj.name == note.filename:
                 tidy_checks_failed += 1
             else:

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -156,6 +156,22 @@ cli_arg_parser.add_argument(
 """,
 )
 cli_arg_parser.add_argument(
+    "-M",
+    "--ignore-format",
+    default="",
+    help="""Set this option with path(s) to ignore (or not ignore)
+when using clang-format. See :std:option:`--ignore` for
+more detail.""",
+)
+cli_arg_parser.add_argument(
+    "-D",
+    "--ignore-tidy",
+    default="",
+    help="""Set this option with path(s) to ignore (or not ignore)
+when using clang-tidy. See :std:option:`--ignore` for
+more detail.""",
+)
+cli_arg_parser.add_argument(
     "-l",
     "--lines-changed-only",
     default="false",

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -1,7 +1,72 @@
-"""Setup the options for CLI arguments."""
+"""Setup the options for :doc:`CLI <../cli_args>` arguments."""
 
 import argparse
-from typing import Optional
+from collections import UserDict
+from typing import Optional, List
+
+
+class Args(UserDict):
+    """A pseudo namespace declaration. Each attribute is initialized with the
+    corresponding :doc:`CLI <../cli_args>` arg's default value."""
+
+    #: See :std:option:`--verbosity`.
+    verbosity: bool = False
+    #: See :std:option:`--database`.
+    database: str = ""
+    #: See :std:option:`--style`.
+    style: str = "llvm"
+    #: See :std:option:`--tidy-checks`.
+    tidy_checks: str = (
+        "boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,"
+        "clang-analyzer-*,cppcoreguidelines-*"
+    )
+    #: See :std:option:`--version`.
+    version: str = ""
+    #: See :std:option:`--extensions`.
+    extensions: List[str] = [
+        "c",
+        "h",
+        "C",
+        "H",
+        "cpp",
+        "hpp",
+        "cc",
+        "hh",
+        "c++",
+        "h++",
+        "cxx",
+        "hxx",
+    ]
+    #: See :std:option:`--repo-root`.
+    repo_root: str = "."
+    #: See :std:option:`--ignore`.
+    ignore: str = ".github"
+    #: See :std:option:`--lines-changed-only`.
+    lines_changed_only: int = 0
+    #: See :std:option:`--files-changed-only`.
+    files_changed_only: bool = False
+    #: See :std:option:`--thread-comments`.
+    thread_comments: str = "false"
+    #: See :std:option:`--step-summary`.
+    step_summary: bool = False
+    #: See :std:option:`--file-annotations`.
+    file_annotations: bool = True
+    #: See :std:option:`--extra-arg`.
+    extra_arg: List[str] = []
+    #: See :std:option:`--no-lgtm`.
+    no_lgtm: bool = True
+    #: These are the optional not-ignored paths passed as positional arguments to the CLI.
+    files: List[str] = []
+    #: See :std:option:`--tidy-review`.
+    tidy_review: bool = False
+    #: See :std:option:`--format-review`.
+    format_review: bool = False
+    #: See :std:option:`--jobs`.
+    jobs: int = 1
+    #: See :std:option:`--ignore-tidy`.
+    ignore_tidy: str = ""
+    #: See :std:option:`--ignore-format`.
+    ignore_format: str = ""
 
 
 cli_arg_parser = argparse.ArgumentParser(

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -62,7 +62,7 @@ class Args(UserDict):
     #: See :std:option:`--format-review`.
     format_review: bool = False
     #: See :std:option:`--jobs`.
-    jobs: int = 1
+    jobs: Optional[int] = 1
     #: See :std:option:`--ignore-tidy`.
     ignore_tidy: str = ""
     #: See :std:option:`--ignore-format`.

--- a/cpp_linter/common_fs/__init__.py
+++ b/cpp_linter/common_fs/__init__.py
@@ -1,8 +1,13 @@
 from os import environ
 from pathlib import Path
-from typing import List, Dict, Any, Union, Tuple, Optional
+from typing import List, Dict, Any, Union, Tuple, Optional, TYPE_CHECKING
 from pygit2 import DiffHunk  # type: ignore
 from ..loggers import logger
+
+if TYPE_CHECKING:  # pragma: no covers
+    # circular import
+    from ..clang_tools.clang_tidy import TidyAdvice
+    from ..clang_tools.clang_format import FormatAdvice
 
 #: A path to generated cache artifacts. (only used when verbosity is in debug mode)
 CACHE_PATH = Path(environ.get("CPP_LINTER_CACHE", ".cpp-linter_cache"))
@@ -38,6 +43,10 @@ class FileObj:
         """A list of line numbers that define the beginning and ending of ranges that
         have added changes. This will be empty if not focusing on lines changed only.
         """
+        #: The results from clang-tidy
+        self.tidy_advice: Optional["TidyAdvice"] = None
+        #: The results from clang-format
+        self.format_advice: Optional["FormatAdvice"] = None
 
     @staticmethod
     def _consolidate_list_to_ranges(numbers: List[int]) -> List[List[int]]:

--- a/cpp_linter/common_fs/__init__.py
+++ b/cpp_linter/common_fs/__init__.py
@@ -1,9 +1,8 @@
 from os import environ
-from os.path import commonpath
-from pathlib import PurePath, Path
+from pathlib import Path
 from typing import List, Dict, Any, Union, Tuple, Optional
 from pygit2 import DiffHunk  # type: ignore
-from .loggers import logger, start_log_group
+from ..loggers import logger
 
 #: A path to generated cache artifacts. (only used when verbosity is in debug mode)
 CACHE_PATH = Path(environ.get("CPP_LINTER_CACHE", ".cpp-linter_cache"))
@@ -148,33 +147,6 @@ class FileObj:
         return None
 
 
-def is_file_in_list(paths: List[str], file_name: str, prompt: str) -> bool:
-    """Determine if a file is specified in a list of paths and/or filenames.
-
-    :param paths: A list of specified paths to compare with. This list can contain a
-        specified file, but the file's path must be included as part of the
-        filename.
-    :param file_name: The file's path & name being sought in the ``paths`` list.
-    :param prompt: A debugging prompt to use when the path is found in the list.
-
-    :returns:
-
-        - True if ``file_name`` is in the ``paths`` list.
-        - False if ``file_name`` is not in the ``paths`` list.
-    """
-    for path in paths:
-        result = commonpath([PurePath(path).as_posix(), PurePath(file_name).as_posix()])
-        if result.replace("\\", "/") == path:
-            logger.debug(
-                '"./%s" is %s as specified in the domain "./%s"',
-                file_name,
-                prompt,
-                path,
-            )
-            return True
-    return False
-
-
 def has_line_changes(
     lines_changed_only: int, diff_chunks: List[List[int]], additions: List[int]
 ) -> bool:
@@ -194,60 +166,6 @@ def has_line_changes(
         or (lines_changed_only == 2 and len(additions) > 0)
         or not lines_changed_only
     )
-
-
-def is_source_or_ignored(
-    file_name: str,
-    ext_list: List[str],
-    ignored: List[str],
-    not_ignored: List[str],
-):
-    """Exclude undesired files (specified by user input :std:option:`--extensions`).
-    This filtering is applied to the :attr:`~cpp_linter.Globals.FILES` attribute.
-
-    :param file_name: The name of file in question.
-    :param ext_list: A list of file extensions that are to be examined.
-    :param ignored: A list of paths to explicitly ignore.
-    :param not_ignored: A list of paths to explicitly not ignore.
-
-    :returns:
-        True if there are files to check. False will invoke a early exit (in
-        `main()`) when no files to be checked.
-    """
-    return PurePath(file_name).suffix.lstrip(".") in ext_list and (
-        is_file_in_list(not_ignored, file_name, "not ignored")
-        or not is_file_in_list(ignored, file_name, "ignored")
-    )
-
-
-def list_source_files(
-    extensions: List[str], ignored: List[str], not_ignored: List[str]
-) -> List[FileObj]:
-    """Make a list of source files to be checked.
-
-    :param extensions: A list of file extensions that should by attended.
-    :param ignored: A list of paths to explicitly ignore.
-    :param not_ignored: A list of paths to explicitly not ignore.
-
-    :returns: A list of `FileObj` objects.
-    """
-    start_log_group("Get list of specified source files")
-
-    root_path = Path(".")
-    files = []
-    for ext in extensions:
-        for rel_path in root_path.rglob(f"*.{ext}"):
-            for parent in rel_path.parts[:-1]:
-                if parent.startswith("."):
-                    break
-            else:
-                file_path = rel_path.as_posix()
-                logger.debug('"./%s" is a source code file', file_path)
-                if is_file_in_list(
-                    not_ignored, file_path, "not ignored"
-                ) or not is_file_in_list(ignored, file_path, "ignored"):
-                    files.append(FileObj(file_path))
-    return files
 
 
 def get_line_cnt_from_cols(file_path: str, offset: int) -> Tuple[int, int]:

--- a/cpp_linter/common_fs/file_filter.py
+++ b/cpp_linter/common_fs/file_filter.py
@@ -198,6 +198,8 @@ class FileFilter:
 
 
 class TidyFileFilter(FileFilter):
+    """A specialized `FileFilter` whose debug prompts indicate clang-tidy preparation."""
+
     def __init__(
         self, extensions: List[str], ignore_value: str, not_ignored: List[str]
     ) -> None:
@@ -205,6 +207,8 @@ class TidyFileFilter(FileFilter):
 
 
 class FormatFileFilter(FileFilter):
+    """A specialized `FileFilter` whose debug prompts indicate clang-format preparation."""
+
     def __init__(
         self, extensions: List[str], ignore_value: str, not_ignored: List[str]
     ) -> None:

--- a/cpp_linter/common_fs/file_filter.py
+++ b/cpp_linter/common_fs/file_filter.py
@@ -1,0 +1,211 @@
+import configparser
+import os
+from pathlib import Path, PurePath
+from typing import List, Optional, Dict
+from . import FileObj
+from ..loggers import logger
+
+
+class FileFilter:
+    """A reusable mechanism for parsing and validating file filters.
+
+    :param extensions: A list of file extensions in which to focus.
+    :param ignore_value: The user input specified via :std:option:`--ignore` CLI
+        argument.
+    :param not_ignored: A list of files or paths that will be explicitly not ignored.
+    :param tool_specific_name: A clang tool name for which the file filter is
+        specifically applied. This only gets used in debug statements.
+    """
+
+    def __init__(
+        self,
+        extensions: List[str],
+        ignore_value: str,
+        not_ignored: List[str],
+        tool_specific_name: Optional[str] = None,
+    ) -> None:
+        #: A list of file extensions that are considered C/C++ sources.
+        self.extensions = extensions
+        #: A dict of ignore patterns (keys) mapped to their effects paths (values).
+        self.ignored: Dict[str, List[Path]] = {}
+        #: A dict of not-ignore patterns (keys) mapped to their effects paths (values).
+        self.not_ignored: Dict[str, List[Path]] = {
+            f: FileFilter._resolve_glob(f) for f in not_ignored
+        }
+        self._tool_name = tool_specific_name or ""
+        self._parse_ignore_option(paths=ignore_value)
+
+    @staticmethod
+    def _resolve_glob(pattern: str):
+        if not pattern:
+            return [Path(".")]
+        return list(Path(".").glob(pattern))
+
+    def parse_submodules(self, path: str = ".gitmodules"):
+        """Automatically detect submodules from given ``path``.
+        This will add each submodule to the `ignored` list unless already specified as
+        `not_ignored`."""
+        git_modules = Path(path)
+        if git_modules.exists():
+            submodules = configparser.ConfigParser()
+            submodules.read(git_modules.resolve().as_posix())
+            for module in submodules.sections():
+                sub_mod_path = submodules[module]["path"]
+                if sub_mod_path not in self.not_ignored:
+                    logger.info(
+                        "Appending submodule to ignored paths: %s", sub_mod_path
+                    )
+                    self.ignored[sub_mod_path] = [Path(sub_mod_path)]
+
+    def _parse_ignore_option(self, paths: str):
+        """Parse a given string of paths (separated by a ``|``) into ``ignored`` and
+        ``not_ignored`` lists of strings.
+
+        :param paths: This argument conforms to the input value of CLI arg
+            :std:option:`--ignore`.
+
+        Results are added accordingly to the `ignored` and `not_ignored` attributes.
+        """
+        if paths:
+            for path in paths.split("|"):
+                path = path.strip()  # strip leading/trailing spaces
+                is_included = path.startswith("!")
+                if is_included:  # strip leading `!`
+                    path = path[1:].lstrip()
+                if path.startswith("./"):
+                    path = path.replace("./", "", 1)  # relative dir is assumed
+
+                # NOTE: A blank string is now the repo-root `path`
+                _glob_result = FileFilter._resolve_glob(path)
+
+                if is_included:
+                    self.not_ignored[path] = _glob_result
+                else:
+                    self.ignored[path] = _glob_result
+
+        tool_name = "" if not self._tool_name else (self._tool_name + " ")
+        if self.ignored:
+            logger.info(
+                "%sIgnoring the following paths/files:\n\t./%s",
+                tool_name,
+                "\n\t./".join(
+                    f.as_posix() for values in self.ignored.values() for f in values
+                ),
+            )
+        if self.not_ignored:
+            logger.info(
+                "%sNot ignoring the following paths/files:\n\t./%s",
+                tool_name,
+                "\n\t./".join(
+                    f.as_posix() for values in self.not_ignored.values() for f in values
+                ),
+            )
+
+    def is_file_in_list(self, ignored: bool, file_name: str) -> bool:
+        """Determine if a file is specified in a list of paths and/or filenames.
+
+        :param ignored: A flag that specifies which set of list to compare with.
+            ``True`` for `ignored` or ``False`` for `not_ignored`.
+        :param file_name: The file's path & name being sought in the ``path_list``.
+
+        :returns:
+
+            - True if ``file_name`` is in the ``path_list``.
+            - False if ``file_name`` is not in the ``path_list``.
+        """
+        file_path = PurePath(file_name)
+        prompt = "ignored" if ignored else "not ignored"
+        tool_name = "" if not self._tool_name else f"[{self._tool_name}] "
+        path_list = self.ignored if ignored else self.not_ignored
+        for pattern, paths in path_list.items():
+            for path in paths:
+                if path.is_dir():
+                    # if path has no parts, then it is considered repo-root
+                    if (
+                        not path.parts
+                        or PurePath(
+                            os.path.commonpath(
+                                [f.as_posix() for f in [file_path, path]]
+                            )
+                        ).as_posix()
+                        == path.as_posix()
+                    ):
+                        logger.debug(
+                            '"%s./%s" is %s as specified in the domain "./%s"',
+                            tool_name,
+                            file_name,
+                            prompt,
+                            pattern,
+                        )
+                        return True
+                if path.is_file() and path.as_posix() == file_path.as_posix():
+                    logger.debug(
+                        "%s./%s is %s as specified by pattern ./%s",
+                        tool_name,
+                        file_name,
+                        prompt,
+                        pattern,
+                    )
+                    return True
+        return False
+
+    def is_source_or_ignored(self, file_name: str) -> bool:
+        """Exclude undesired files (specified by user input :std:option:`--extensions`
+        and :std:option:`--ignore` options).
+
+        :param file_name: The name of file in question.
+
+        :returns:
+            ``True`` if (in order of precedence)
+
+            .. task-list::
+                :custom:
+
+                - [x] ``file_name`` is using one of the specified `extensions`.
+                - [x] ``file_name`` is in `not_ignored`.
+                - [x] ``file_name`` is not in `ignored`.
+
+            Otherwise ``False``.
+        """
+        return PurePath(file_name).suffix.lstrip(".") in self.extensions and (
+            self.is_file_in_list(ignored=False, file_name=file_name)
+            or not self.is_file_in_list(ignored=True, file_name=file_name)
+        )
+
+    def list_source_files(self) -> List[FileObj]:
+        """Make a list of source files to be checked.
+        This will recursively walk the file tree collecting matches to
+        anything that would return ``True`` from `is_source_or_ignored()`.
+
+        :returns: A list of `FileObj` objects without diff information.
+        """
+
+        root_path = Path(".")
+        files = []
+        for ext in self.extensions:
+            for rel_path in root_path.rglob(f"*.{ext}"):
+                for parent in rel_path.parts[:-1]:
+                    if parent.startswith("."):
+                        break
+                else:
+                    file_path = rel_path.as_posix()
+                    logger.debug('"./%s" is a source code file', file_path)
+                    if self.is_file_in_list(
+                        ignored=False, file_name=file_path
+                    ) or not self.is_file_in_list(ignored=True, file_name=file_path):
+                        files.append(FileObj(file_path))
+        return files
+
+
+class TidyFileFilter(FileFilter):
+    def __init__(
+        self, extensions: List[str], ignore_value: str, not_ignored: List[str]
+    ) -> None:
+        super().__init__(extensions, ignore_value, not_ignored, "clang-tidy ")
+
+
+class FormatFileFilter(FileFilter):
+    def __init__(
+        self, extensions: List[str], ignore_value: str, not_ignored: List[str]
+    ) -> None:
+        super().__init__(extensions, ignore_value, not_ignored, "clang-format ")

--- a/cpp_linter/common_fs/file_filter.py
+++ b/cpp_linter/common_fs/file_filter.py
@@ -146,12 +146,9 @@ class FileFilter:
         :returns:
             ``True`` if (in order of precedence)
 
-            .. task-list::
-                :custom:
-
-                - [x] ``file_name`` is using one of the specified `extensions`.
-                - [x] ``file_name`` is in `not_ignored`.
-                - [x] ``file_name`` is not in `ignored`.
+            - ``file_name`` is using one of the specified `extensions` AND
+            - ``file_name`` is in `not_ignored` OR
+            - ``file_name`` is not in `ignored`.
 
             Otherwise ``False``.
         """

--- a/cpp_linter/git/git_str.py
+++ b/cpp_linter/git/git_str.py
@@ -4,7 +4,8 @@ binds to). The `parse_diff()` function here is only used when
 
 import re
 from typing import Optional, List, Tuple, cast
-from ..common_fs import FileObj, is_source_or_ignored, has_line_changes
+from ..common_fs import FileObj, has_line_changes
+from ..common_fs.file_filter import FileFilter
 from ..loggers import logger
 
 
@@ -38,17 +39,13 @@ def _get_filename_from_diff(front_matter: str) -> Optional[re.Match]:
 
 def parse_diff(
     full_diff: str,
-    extensions: List[str],
-    ignored: List[str],
-    not_ignored: List[str],
+    file_filter: FileFilter,
     lines_changed_only: int,
 ) -> List[FileObj]:
     """Parse a given diff into file objects.
 
     :param full_diff: The complete diff for an event.
-    :param extensions: A list of file extensions to focus on only.
-    :param ignored: A list of paths or files to ignore.
-    :param not_ignored: A list of paths or files to explicitly not ignore.
+    :param file_filter: A `FileFilter` object.
     :param lines_changed_only: A value that dictates what file changes to focus on.
     :returns: A `list` of `FileObj` instances containing information about the files
         changed.
@@ -68,7 +65,7 @@ def parse_diff(
         filename = cast(str, filename_match.groups(0)[0])
         if first_hunk is None:
             continue
-        if not is_source_or_ignored(filename, extensions, ignored, not_ignored):
+        if not file_filter.is_source_or_ignored(filename):
             continue
         diff_chunks, additions = _parse_patch(diff[first_hunk.start() :])
         if has_line_changes(lines_changed_only, diff_chunks, additions):

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -12,6 +12,7 @@ from ..common_fs import FileObj
 from ..common_fs.file_filter import FileFilter
 from ..clang_tools.clang_format import FormatAdvice
 from ..clang_tools.clang_tidy import TidyAdvice
+from ..cli import Args
 from ..loggers import logger, log_response_msg
 
 
@@ -284,13 +285,7 @@ class RestApiClient(ABC):
         files: List[FileObj],
         format_advice: List[FormatAdvice],
         tidy_advice: List[TidyAdvice],
-        thread_comments: str,
-        no_lgtm: bool,
-        step_summary: bool,
-        file_annotations: bool,
-        style: str,
-        tidy_review: bool,
-        format_review: bool,
+        args: Args,
     ):
         """Post action's results using REST API.
 
@@ -299,20 +294,7 @@ class RestApiClient(ABC):
             ``files``.
         :param tidy_advice: A list of clang-tidy advice parallel to the list of
             ``files``.
-        :param thread_comments: A flag that describes if how thread comments should
-            be handled. See :std:option:`--thread-comments`.
-        :param no_lgtm: A flag to control if a "Looks Good To Me" comment should be
-            posted. If this is `False`, then an outdated bot comment will still be
-            deleted. See :std:option:`--no-lgtm`.
-        :param step_summary: A flag that describes if a step summary should
-            be posted. See :std:option:`--step-summary`.
-        :param file_annotations: A flag that describes if file annotations should
-            be posted. See :std:option:`--file-annotations`.
-        :param style: The style used for clang-format. See :std:option:`--style`.
-        :param tidy_review: A flag to enable/disable creating a diff suggestion for
-            PR review comments using clang-tidy.
-        :param format_review: A flag to enable/disable creating a diff suggestion for
-            PR review comments using clang-format.
+        :param args: A namespace of arguments parsed from the :doc:`CLI <../cli_args>`.
         """
         raise NotImplementedError("Must be defined in the derivative")
 

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -9,6 +9,7 @@ import time
 from typing import Optional, Dict, List, Any, cast, NamedTuple
 import requests
 from ..common_fs import FileObj
+from ..common_fs.file_filter import FileFilter
 from ..clang_tools.clang_format import FormatAdvice
 from ..clang_tools.clang_tidy import TidyAdvice
 from ..loggers import logger, log_response_msg
@@ -153,16 +154,12 @@ class RestApiClient(ABC):
 
     def get_list_of_changed_files(
         self,
-        extensions: List[str],
-        ignored: List[str],
-        not_ignored: List[str],
+        file_filter: FileFilter,
         lines_changed_only: int,
     ) -> List[FileObj]:
         """Fetch a list of the event's changed files.
 
-        :param extensions: A list of file extensions to focus on only.
-        :param ignored: A list of paths or files to ignore.
-        :param not_ignored: A list of paths or files to explicitly not ignore.
+        :param file_filter: A `FileFilter` obj to filter files.
         :param lines_changed_only: A value that dictates what file changes to focus on.
         """
         raise NotImplementedError("must be implemented in the derivative")

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -15,7 +15,7 @@ from os import environ
 from pathlib import Path
 import urllib.parse
 import sys
-from typing import Dict, List, Any, cast, Optional, Tuple, Union, Sequence
+from typing import Dict, List, Any, cast, Optional, Tuple, Union
 
 from pygit2 import Patch  # type: ignore
 from ..common_fs import FileObj, CACHE_PATH
@@ -146,20 +146,16 @@ class GithubApiClient(RestApiClient):
     def post_feedback(
         self,
         files: List[FileObj],
-        format_advice: List[FormatAdvice],
-        tidy_advice: List[TidyAdvice],
         args: Args,
     ):
-        format_checks_failed = tally_format_advice(format_advice=format_advice)
-        tidy_checks_failed = tally_tidy_advice(files=files, tidy_advice=tidy_advice)
+        format_checks_failed = tally_format_advice(files)
+        tidy_checks_failed = tally_tidy_advice(files)
         checks_failed = format_checks_failed + tidy_checks_failed
         comment: Optional[str] = None
 
         if args.step_summary and "GITHUB_STEP_SUMMARY" in environ:
             comment = super().make_comment(
                 files=files,
-                format_advice=format_advice,
-                tidy_advice=tidy_advice,
                 format_checks_failed=format_checks_failed,
                 tidy_checks_failed=tidy_checks_failed,
                 len_limit=None,
@@ -170,8 +166,6 @@ class GithubApiClient(RestApiClient):
         if args.file_annotations:
             self.make_annotations(
                 files=files,
-                format_advice=format_advice,
-                tidy_advice=tidy_advice,
                 style=args.style,
             )
 
@@ -189,8 +183,6 @@ class GithubApiClient(RestApiClient):
             if comment is None or len(comment) >= 65535:
                 comment = super().make_comment(
                     files=files,
-                    format_advice=format_advice,
-                    tidy_advice=tidy_advice,
                     format_checks_failed=format_checks_failed,
                     tidy_checks_failed=tidy_checks_failed,
                     len_limit=65535,
@@ -217,8 +209,6 @@ class GithubApiClient(RestApiClient):
         ):
             self.post_review(
                 files=files,
-                tidy_advice=tidy_advice,
-                format_advice=format_advice,
                 tidy_review=args.tidy_review,
                 format_review=args.format_review,
                 no_lgtm=args.no_lgtm,
@@ -227,41 +217,39 @@ class GithubApiClient(RestApiClient):
     def make_annotations(
         self,
         files: List[FileObj],
-        format_advice: List[FormatAdvice],
-        tidy_advice: List[TidyAdvice],
         style: str,
     ) -> None:
         """Use github log commands to make annotations from clang-format and
         clang-tidy output.
 
         :param files: A list of objects, each describing a file's information.
-        :param format_advice: A list of clang-format advice parallel to the list of
-            ``files``.
-        :param tidy_advice: A list of clang-tidy advice parallel to the list of
-            ``files``.
         :param style: The chosen code style guidelines. The value 'file' is replaced
             with 'custom style'.
         """
         style_guide = formalize_style_name(style)
-        for advice, file in zip(format_advice, files):
-            if advice.replaced_lines:
+        for file_obj in files:
+            if not file_obj.format_advice:
+                continue
+            if file_obj.format_advice.replaced_lines:
                 line_list = []
-                for fix in advice.replaced_lines:
+                for fix in file_obj.format_advice.replaced_lines:
                     line_list.append(str(fix.line))
                 output = "::notice file="
-                name = file.name
+                name = file_obj.name
                 output += f"{name},title=Run clang-format on {name}::File {name}"
                 output += f" does not conform to {style_guide} style guidelines. "
                 output += "(lines {lines})".format(lines=", ".join(line_list))
                 log_commander.info(output)
-        for concerns, file in zip(tidy_advice, files):
-            for note in concerns.notes:
-                if note.filename == file.name:
+        for file_obj in files:
+            if not file_obj.tidy_advice:
+                continue
+            for note in file_obj.tidy_advice.notes:
+                if note.filename == file_obj.name:
                     output = "::{} ".format(
                         "notice" if note.severity.startswith("note") else note.severity
                     )
                     output += "file={file},line={line},title={file}:{line}:".format(
-                        file=file.name, line=note.line
+                        file=file_obj.name, line=note.line
                     )
                     output += "{cols} [{diag}]::{info}".format(
                         cols=note.cols,
@@ -355,8 +343,6 @@ class GithubApiClient(RestApiClient):
     def post_review(
         self,
         files: List[FileObj],
-        tidy_advice: List[TidyAdvice],
-        format_advice: List[FormatAdvice],
         tidy_review: bool,
         format_review: bool,
         no_lgtm: bool,
@@ -379,14 +365,14 @@ class GithubApiClient(RestApiClient):
         summary_only = (
             environ.get("CPP_LINTER_PR_REVIEW_SUMMARY_ONLY", "false") == "true"
         )
-        advice: Dict[str, Sequence[Union[TidyAdvice, FormatAdvice]]] = {}
+        advice: Dict[str, bool] = {}
         if format_review:
-            advice["clang-format"] = format_advice
+            advice["clang-format"] = False
         if tidy_review:
-            advice["clang-tidy"] = tidy_advice
-        for tool_name, tool_advice in advice.items():
+            advice["clang-tidy"] = True
+        for tool_name, tidy_tool in advice.items():
             comments, total, patch = self.create_review_comments(
-                files, tool_advice, summary_only
+                files, tidy_tool, summary_only
             )
             total_changes += total
             if not summary_only:
@@ -418,20 +404,27 @@ class GithubApiClient(RestApiClient):
     @staticmethod
     def create_review_comments(
         files: List[FileObj],
-        tool_advice: Sequence[Union[FormatAdvice, TidyAdvice]],
+        tidy_tool: bool,
         summary_only: bool,
     ) -> Tuple[List[Dict[str, Any]], int, str]:
         """Creates a batch of comments for a specific clang tool's PR review"""
         total = 0
         comments = []
         full_patch = ""
-        for file, advice in zip(files, tool_advice):
-            assert advice.patched, f"No suggested patch found for {file.name}"
+        for file_obj in files:
+            tool_advice: Optional[Union[TidyAdvice, FormatAdvice]]
+            if tidy_tool:
+                tool_advice = file_obj.tidy_advice
+            else:
+                tool_advice = file_obj.format_advice
+            if not tool_advice:
+                continue
+            assert tool_advice.patched, f"No suggested patch found for {file_obj.name}"
             patch = Patch.create_from(
-                old=Path(file.name).read_bytes(),
-                new=advice.patched,
-                old_as_path=file.name,
-                new_as_path=file.name,
+                old=Path(file_obj.name).read_bytes(),
+                new=tool_advice.patched,
+                old_as_path=file_obj.name,
+                new_as_path=file_obj.name,
                 context_lines=0,  # trim all unchanged lines from start/end of hunks
             )
             full_patch += patch.text
@@ -439,20 +432,22 @@ class GithubApiClient(RestApiClient):
                 total += 1
                 if summary_only:
                     continue
-                new_hunk_range = file.is_hunk_contained(hunk)
+                new_hunk_range = file_obj.is_hunk_contained(hunk)
                 if new_hunk_range is None:
                     continue
                 start_lines, end_lines = new_hunk_range
-                comment: Dict[str, Any] = {"path": file.name}
+                comment: Dict[str, Any] = {"path": file_obj.name}
                 body = ""
-                if isinstance(advice, TidyAdvice):
+                if tidy_tool and file_obj.tidy_advice:
                     body += "### clang-tidy "
-                    diagnostics = advice.diagnostics_in_range(start_lines, end_lines)
+                    diagnostics = file_obj.tidy_advice.diagnostics_in_range(
+                        start_lines, end_lines
+                    )
                     if diagnostics:
                         body += "diagnostics\n" + diagnostics
                     else:
                         body += "suggestions\n"
-                else:
+                elif not tidy_tool:
                     body += "### clang-format suggestions\n"
                 if start_lines < end_lines:
                     comment["start_line"] = start_lines
@@ -472,24 +467,24 @@ class GithubApiClient(RestApiClient):
                 comment["body"] = body
                 comments.append(comment)
 
-        if tool_advice and isinstance(tool_advice[0], TidyAdvice):
             # now check for clang-tidy warnings with no fixes applied
-            for file, tidy_advice in zip(files, tool_advice):
-                assert isinstance(tidy_advice, TidyAdvice)
-                for note in tidy_advice.notes:
+            if tidy_tool and file_obj.tidy_advice:
+                for note in file_obj.tidy_advice.notes:
                     if not note.applied_fixes:  # if no fix was applied
                         total += 1
                         line_numb = int(note.line)
-                        if file.is_range_contained(start=line_numb, end=line_numb + 1):
+                        if file_obj.is_range_contained(
+                            start=line_numb, end=line_numb + 1
+                        ):
                             diag: Dict[str, Any] = {
-                                "path": file.name,
+                                "path": file_obj.name,
                                 "line": note.line,
                             }
-                            body = f"### clang-tidy diagnostic\n**{file.name}:"
+                            body = f"### clang-tidy diagnostic\n**{file_obj.name}:"
                             body += f"{note.line}:{note.cols}:** {note.severity}: "
                             body += f"[{note.diagnostic_link}]\n> {note.rationale}\n"
                             if note.fixit_lines:
-                                body += f'```{Path(file.name).suffix.lstrip(".")}\n'
+                                body += f'```{Path(file_obj.name).suffix.lstrip(".")}\n'
                                 for line in note.fixit_lines:
                                     body += f"{line}\n"
                                 body += "```\n"

--- a/docs/API-Reference/cpp_linter.cli.rst
+++ b/docs/API-Reference/cpp_linter.cli.rst
@@ -1,0 +1,6 @@
+``cli``
+==============
+
+.. automodule:: cpp_linter.cli
+    :members:
+    :undoc-members:

--- a/docs/API-Reference/cpp_linter.common_fs.file_filter.rst
+++ b/docs/API-Reference/cpp_linter.common_fs.file_filter.rst
@@ -1,0 +1,5 @@
+``common_fs.file_filter``
+=========================
+
+.. automodule:: cpp_linter.common_fs.file_filter
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,6 @@ release = get_version("cpp-linter")
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 extensions = [
     "sphinx_immaterial",
-    "sphinx_immaterial.task_lists",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ release = get_version("cpp-linter")
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 extensions = [
     "sphinx_immaterial",
+    "sphinx_immaterial.task_lists",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -225,6 +225,7 @@ REQUIRED_VERSIONS = {
     "1.6.0": ["step_summary"],
     "1.4.7": ["extra_arg"],
     "1.8.1": ["jobs"],
+    "1.9.0": ["ignore_tidy", "ignore_format"],
 }
 
 PERMISSIONS = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+from io import StringIO
 from pathlib import Path
 import time
 from typing import Optional
@@ -11,7 +12,7 @@ import docutils
 from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxRole
 from sphinx_immaterial.inline_icons import load_svg_into_builder_env
-from cpp_linter.cli import cli_arg_parser
+from cpp_linter.cli import get_cli_parser
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -246,37 +247,61 @@ def setup(app: Sphinx):
     app.add_role("badge-permission", CliBadgePermission())
     app.add_role("badge-experimental", CliBadgeExperimental())
 
-    doc = "Command Line Interface Options\n==============================\n\n"
-    doc += ".. note::\n\n    These options have a direct relationship with the\n    "
-    doc += "`cpp-linter-action user inputs "
-    doc += "<https://cpp-linter.github.io/cpp-linter-action/inputs-outputs#inputs>`_. "
-    doc += "Although, some default values may differ.\n\n"
-
-    args = cli_arg_parser._optionals._actions
-    for arg in args:
-        aliases = arg.option_strings
-        if not aliases or arg.default == "==SUPPRESS==":
-            continue
-        doc += "\n.. std:option:: " + ", ".join(aliases) + "\n"
-        assert arg.help is not None
-        help = arg.help[: arg.help.find("Defaults to")]
-        for ver, names in REQUIRED_VERSIONS.items():
-            if arg.dest in names:
-                req_ver = ver
-                break
-        else:
-            req_ver = "1.4.6"
-        doc += f"\n    :badge-version:`{req_ver}` "
-        doc += f":badge-default:`'{arg.default or ''}'` "
-        if arg.dest in EXPERIMENTAL:
-            doc += ":badge-experimental:`experimental` "
-        for name, permission in PERMISSIONS.items():
-            if name == arg.dest:
-                link, spec = permission
-                doc += f":badge-permission:`{link} {spec}`"
-                break
-        doc += "\n\n    "
-        doc += "\n    ".join(help.splitlines()) + "\n"
     cli_doc = Path(app.srcdir, "cli_args.rst")
-    cli_doc.unlink(missing_ok=True)
-    cli_doc.write_text(doc)
+    with open(cli_doc, mode="w") as doc:
+        doc.write("Command Line Interface Options\n==============================\n\n")
+        doc.write(
+            ".. note::\n\n    These options have a direct relationship with the\n    "
+        )
+        doc.write("`cpp-linter-action user inputs ")
+        doc.write(
+            "<https://cpp-linter.github.io/cpp-linter-action/inputs-outputs#inputs>`_. "
+        )
+        doc.write("Although, some default values may differ.\n\n")
+        parser = get_cli_parser()
+        doc.write(".. code-block:: text\n    :caption: Usage\n    :class: no-copy\n\n")
+        parser.prog = "cpp-linter"
+        str_buf = StringIO()
+        parser.print_usage(str_buf)
+        usage = str_buf.getvalue()
+        start = usage.find(parser.prog)
+        for line in usage.splitlines():
+            doc.write(f"    {line[start:]}\n")
+
+        doc.write("\n\nPositional Arguments\n")
+        doc.write("--------------------\n\n")
+        args = parser._optionals._actions
+        for arg in args:
+            if arg.option_strings:
+                continue
+            assert arg.dest is not None
+            doc.write(f"\n.. std:option:: {arg.dest.lower()}\n\n")
+            assert arg.help is not None
+            doc.write("\n    ".join(arg.help.splitlines()))
+
+        doc.write("\n\nOptional Arguments")
+        doc.write("\n------------------\n\n")
+        for arg in args:
+            aliases = arg.option_strings
+            if not aliases or arg.default == "==SUPPRESS==":
+                continue
+            doc.write("\n.. std:option:: " + ", ".join(aliases) + "\n")
+            assert arg.help is not None
+            help = arg.help[: arg.help.find("Defaults to")]
+            for ver, names in REQUIRED_VERSIONS.items():
+                if arg.dest in names:
+                    req_ver = ver
+                    break
+            else:
+                req_ver = "1.4.6"
+            doc.write(f"\n    :badge-version:`{req_ver}` ")
+            doc.write(f":badge-default:`'{arg.default or ''}'` ")
+            if arg.dest in EXPERIMENTAL:
+                doc.write(":badge-experimental:`experimental` ")
+            for name, permission in PERMISSIONS.items():
+                if name == arg.dest:
+                    link, spec = permission
+                    doc.write(f":badge-permission:`{link} {spec}`")
+                    break
+            doc.write("\n\n    ")
+            doc.write("\n    ".join(help.splitlines()) + "\n")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@
    API-Reference/cpp_linter.git
    API-Reference/cpp_linter.git.git_str
    API-Reference/cpp_linter.loggers
+   API-Reference/cpp_linter.cli
    API-Reference/cpp_linter.common_fs
    API-Reference/cpp_linter.common_fs.file_filter
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@
    API-Reference/cpp_linter.git.git_str
    API-Reference/cpp_linter.loggers
    API-Reference/cpp_linter.common_fs
+   API-Reference/cpp_linter.common_fs.file_filter
 
 .. toctree::
    :hidden:

--- a/tests/capture_tools_output/test_database_path.py
+++ b/tests/capture_tools_output/test_database_path.py
@@ -5,8 +5,8 @@ from pathlib import Path, PurePath
 import logging
 import os
 import re
-import sys
 import shutil
+import subprocess
 import pytest
 from cpp_linter.loggers import logger
 from cpp_linter.common_fs import FileObj, CACHE_PATH
@@ -15,7 +15,6 @@ from cpp_linter.clang_tools import capture_clang_tools_output
 from cpp_linter.clang_tools.clang_format import tally_format_advice
 from cpp_linter.clang_tools.clang_tidy import tally_tidy_advice
 from cpp_linter.cli import Args
-from mesonbuild.mesonmain import main as meson  # type: ignore
 
 CLANG_TIDY_COMMAND = re.compile(r'clang-tidy[^\s]*\s(.*)"')
 
@@ -57,7 +56,7 @@ def test_db_detection(
     args.extensions = ["cpp", "hpp"]
     args.lines_changed_only = 0  # analyze complete file
 
-    _ = capture_clang_tools_output(files, args=args)
+    capture_clang_tools_output(files, args=args)
     stdout = capsys.readouterr().out
     assert "Error while trying to load a compilation database" not in stdout
     msg_match = CLANG_TIDY_COMMAND.search(stdout)
@@ -81,12 +80,8 @@ def test_ninja_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     (tmp_path_demo / "build").mkdir(parents=True)
     monkeypatch.setenv("COVERAGE_FILE", str(Path.cwd() / ".coverage"))
     monkeypatch.chdir(str(tmp_path_demo))
-    monkeypatch.setattr(sys, "argv", ["meson", "init"])
-    meson()
-    monkeypatch.setattr(
-        sys, "argv", ["meson", "setup", "--backend=ninja", "build", "."]
-    )
-    meson()
+    subprocess.run(["meson", "init"])
+    subprocess.run(["meson", "setup", "--backend=ninja", "build", "."])
     monkeypatch.setenv("CPP_LINTER_PYTEST_NO_RICH", "1")
 
     logger.setLevel(logging.DEBUG)
@@ -101,9 +96,9 @@ def test_ninja_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     args.lines_changed_only = 0  # analyze complete file
 
     # run clang-tidy and verify paths of project files were matched with database paths
-    (format_advice, tidy_advice) = capture_clang_tools_output(files, args=args)
+    capture_clang_tools_output(files, args=args)
     found_project_file = False
-    for concern in tidy_advice:
+    for concern in [a.tidy_advice for a in files if a.tidy_advice]:
         for note in concern.notes:
             if note.filename.endswith("demo.cpp") or note.filename.endswith("demo.hpp"):
                 assert not Path(note.filename).is_absolute()
@@ -111,12 +106,10 @@ def test_ninja_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     if not found_project_file:  # pragma: no cover
         pytest.fail("no project files raised concerns with clang-tidy")
 
-    format_checks_failed = tally_format_advice(format_advice=format_advice)
-    tidy_checks_failed = tally_tidy_advice(files=files, tidy_advice=tidy_advice)
+    format_checks_failed = tally_format_advice(files)
+    tidy_checks_failed = tally_tidy_advice(files)
     comment = GithubApiClient.make_comment(
         files=files,
-        format_advice=format_advice,
-        tidy_advice=tidy_advice,
         tidy_checks_failed=tidy_checks_failed,
         format_checks_failed=format_checks_failed,
     )

--- a/tests/capture_tools_output/test_database_path.py
+++ b/tests/capture_tools_output/test_database_path.py
@@ -59,6 +59,9 @@ def test_db_detection(
         tidy_review=False,
         format_review=False,
         num_workers=None,
+        extensions=["cpp", "hpp"],
+        tidy_ignore="",
+        format_ignore="",
     )
     stdout = capsys.readouterr().out
     assert "Error while trying to load a compilation database" not in stdout
@@ -106,6 +109,9 @@ def test_ninja_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         tidy_review=False,
         format_review=False,
         num_workers=None,
+        extensions=["cpp", "hpp"],
+        tidy_ignore="",
+        format_ignore="",
     )
     found_project_file = False
     for concern in tidy_advice:

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -21,7 +21,7 @@ from cpp_linter.clang_tools.clang_format import tally_format_advice, FormatAdvic
 from cpp_linter.clang_tools.clang_tidy import tally_tidy_advice, TidyAdvice
 from cpp_linter.loggers import log_commander, logger
 from cpp_linter.rest_api.github_api import GithubApiClient
-from cpp_linter.cli import cli_arg_parser, Args
+from cpp_linter.cli import get_cli_parser, Args
 from cpp_linter.common_fs.file_filter import FileFilter
 
 
@@ -492,7 +492,7 @@ def test_tidy_extra_args(
     for a in user_input:
         cli_in.append(f'--extra-arg="{a}"')
     logger.setLevel(logging.INFO)
-    args = cli_arg_parser.parse_args(cli_in, namespace=Args())
+    args = get_cli_parser().parse_args(cli_in, namespace=Args())
     assert len(user_input) == len(args.extra_arg)
     _, _ = capture_clang_tools_output(files=[FileObj("tests/demo/demo.cpp")], args=args)
     stdout = capsys.readouterr().out

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -281,6 +281,9 @@ def test_format_annotations(
         tidy_review=False,
         format_review=False,
         num_workers=None,
+        extensions=["c", "h", "cpp", "hpp"],
+        tidy_ignore="",
+        format_ignore="",
     )
     assert [note for note in format_advice]
     assert not [note for concern in tidy_advice for note in concern.notes]
@@ -362,6 +365,9 @@ def test_tidy_annotations(
         tidy_review=False,
         format_review=False,
         num_workers=None,
+        extensions=["c", "h", "cpp", "hpp"],
+        tidy_ignore="",
+        format_ignore="",
     )
     assert [note for concern in tidy_advice for note in concern.notes]
     assert not [note for note in format_advice]
@@ -417,6 +423,9 @@ def test_all_ok_comment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         tidy_review=False,
         format_review=False,
         num_workers=None,
+        extensions=["cpp", "hpp"],
+        tidy_ignore="",
+        format_ignore="",
     )
     comment, format_checks_failed, tidy_checks_failed = make_comment(
         files, format_advice, tidy_advice
@@ -512,6 +521,9 @@ def test_tidy_extra_args(
         tidy_review=False,
         format_review=False,
         num_workers=None,
+        extensions=["cpp", "hpp"],
+        tidy_ignore="",
+        format_ignore="",
     )
     stdout = capsys.readouterr().out
     msg_match = CLANG_TIDY_COMMAND.search(stdout)

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -22,6 +22,8 @@ from cpp_linter.clang_tools.clang_tidy import tally_tidy_advice, TidyAdvice
 from cpp_linter.loggers import log_commander, logger
 from cpp_linter.rest_api.github_api import GithubApiClient
 from cpp_linter.cli import cli_arg_parser
+from cpp_linter.common_fs.file_filter import FileFilter
+
 
 CLANG_VERSION = os.getenv("CLANG_VERSION", "16")
 CLANG_TIDY_COMMAND = re.compile(r'clang-tidy[^\s]*\s(.*)"')
@@ -155,9 +157,9 @@ def prep_tmp_dir(
     monkeypatch.chdir(str(repo_cache))
     CACHE_PATH.mkdir(exist_ok=True)
     files = gh_client.get_list_of_changed_files(
-        extensions=["c", "h", "hpp", "cpp"],
-        ignored=[".github"],
-        not_ignored=[],
+        FileFilter(
+            extensions=["c", "h", "hpp", "cpp"], ignore_value=".github", not_ignored=[]
+        ),
         lines_changed_only=lines_changed_only,
     )
     gh_client.verify_files_are_present(files)
@@ -208,9 +210,7 @@ def test_lines_changed_only(
     CACHE_PATH.mkdir(exist_ok=True)
     gh_client = prep_api_client(monkeypatch, repo, commit)
     files = gh_client.get_list_of_changed_files(
-        extensions=extensions,
-        ignored=[".github"],
-        not_ignored=[],
+        FileFilter(extensions=extensions, ignore_value=".github", not_ignored=[]),
         lines_changed_only=lines_changed_only,
     )
     if files:
@@ -474,9 +474,7 @@ def test_parse_diff(
     Path(CACHE_PATH).mkdir()
     files = parse_diff(
         get_diff(),
-        extensions=["cpp", "hpp"],
-        ignored=[],
-        not_ignored=[],
+        FileFilter(extensions=["cpp", "hpp"], ignore_value="", not_ignored=[]),
         lines_changed_only=0,
     )
     if sha == TEST_REPO_COMMIT_PAIRS[4]["commit"] or patch:

--- a/tests/comments/test_comments.py
+++ b/tests/comments/test_comments.py
@@ -65,6 +65,9 @@ def test_post_feedback(
         tidy_review=False,
         format_review=False,
         num_workers=None,
+        extensions=["cpp", "hpp"],
+        tidy_ignore="",
+        format_ignore="",
     )
     # add a non project file to tidy_advice to intentionally cover a log.debug()
     assert tidy_advice

--- a/tests/comments/test_comments.py
+++ b/tests/comments/test_comments.py
@@ -8,7 +8,7 @@ import pytest
 from cpp_linter.rest_api.github_api import GithubApiClient
 from cpp_linter.clang_tools import capture_clang_tools_output
 from cpp_linter.clang_tools.clang_tidy import TidyNotification
-from cpp_linter.common_fs import list_source_files
+from cpp_linter.common_fs.file_filter import FileFilter
 from cpp_linter.loggers import logger
 
 TEST_REPO = "cpp-linter/test-cpp-linter-action"
@@ -47,11 +47,12 @@ def test_post_feedback(
     no_lgtm: bool,
 ):
     """A mock test of posting comments and step summary"""
-    files = list_source_files(
+    file_filter = FileFilter(
         extensions=["cpp", "hpp"],
-        ignored=["tests/capture_tools_output"],
+        ignore_value="tests/capture_tools_output",
         not_ignored=[],
     )
+    files = file_filter.list_source_files()
     assert files
     format_advice, tidy_advice = capture_clang_tools_output(
         files,

--- a/tests/ignored_paths/test_ignored_paths.py
+++ b/tests/ignored_paths/test_ignored_paths.py
@@ -66,4 +66,4 @@ def test_ignore_submodule(monkeypatch: pytest.MonkeyPatch):
 def test_positional_arg(user_input: List[str]):
     """Make sure positional arg value(s) are added to not_ignored list."""
     file_filter = FileFilter(not_ignored=user_input)
-    assert set([p for p in user_input]) == file_filter.not_ignored
+    assert set(user_input) == file_filter.not_ignored

--- a/tests/ignored_paths/test_ignored_paths.py
+++ b/tests/ignored_paths/test_ignored_paths.py
@@ -1,6 +1,6 @@
 """Tests that focus on the ``ignore`` option's parsing."""
 
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import List
 import pytest
 from cpp_linter.common_fs.file_filter import FileFilter
@@ -38,17 +38,17 @@ def test_ignore(
 ):
     """test ignoring of a specified path."""
     caplog.set_level(10)
-    file_filter = FileFilter(extensions=[], ignore_value=user_in, not_ignored=[])
+    file_filter = FileFilter(ignore_value=user_in)
     for p in is_ignored:
-        assert file_filter.is_file_in_list(ignored=True, file_name=p)
+        assert file_filter.is_file_in_list(ignored=True, file_name=PurePath(p))
     for p in is_not_ignored:
-        assert file_filter.is_file_in_list(ignored=False, file_name=p)
+        assert file_filter.is_file_in_list(ignored=False, file_name=PurePath(p))
 
 
 def test_ignore_submodule(monkeypatch: pytest.MonkeyPatch):
     """test auto detection of submodules and ignore the paths appropriately."""
     monkeypatch.chdir(str(Path(__file__).parent))
-    file_filter = FileFilter(extensions=[], ignore_value="!pybind11", not_ignored=[])
+    file_filter = FileFilter(ignore_value="!pybind11")
     file_filter.parse_submodules()
     for ignored_submodule in ["RF24", "RF24Network", "RF24Mesh"]:
         assert ignored_submodule in file_filter.ignored
@@ -60,5 +60,5 @@ def test_ignore_submodule(monkeypatch: pytest.MonkeyPatch):
 )
 def test_positional_arg(user_input: List[str]):
     """Make sure positional arg value(s) are added to not_ignored list."""
-    file_filter = FileFilter(extensions=[], ignore_value="", not_ignored=user_input)
-    assert {p: [] for p in user_input} == file_filter.not_ignored
+    file_filter = FileFilter(not_ignored=user_input)
+    assert set([p for p in user_input]) == file_filter.not_ignored

--- a/tests/ignored_paths/test_ignored_paths.py
+++ b/tests/ignored_paths/test_ignored_paths.py
@@ -10,23 +10,28 @@ from cpp_linter.common_fs.file_filter import FileFilter
     "user_in,is_ignored,is_not_ignored",
     [
         (
-            "src|!src/file.h|!",
+            "src | !src/file.h |!",
             ["src/file.h", "src/sub/path/file.h"],
             ["src/file.h", "file.h"],
         ),
         (
-            "!src|./",
+            "! src | ./",
             ["file.h", "sub/path/file.h"],
             ["src/file.h", "src/sub/path/file.h"],
         ),
         (
-            "tests/**|!tests/demo|!cpp_linter/*.py|",
+            "tests/** | !tests/demo| ! cpp_linter/*.py|",
             [
                 "tests/test_misc.py",
                 "tests/ignored_paths",
                 "tests/ignored_paths/.gitmodules",
             ],
             ["tests/demo/demo.cpp", "tests/demo", "cpp_linter/__init__.py"],
+        ),
+        (
+            "examples/*/build | !src",
+            ["examples/linux/build/some/file.c"],
+            ["src/file.h", "src/sub/path/file.h"],
         ),
     ],
 )

--- a/tests/ignored_paths/test_ignored_paths.py
+++ b/tests/ignored_paths/test_ignored_paths.py
@@ -10,14 +10,14 @@ from cpp_linter.common_fs.file_filter import FileFilter
     "user_in,is_ignored,is_not_ignored",
     [
         (
-            "tests|!tests/demo/demo.h|!",
-            ["tests/test_misc.py", "tests/demo/demo.cpp"],
-            ["tests/demo/demo.h", "pyproject.toml"],
+            "src|!src/file.h|!",
+            ["src/file.h", "src/sub/path/file.h"],
+            ["src/file.h", "file.h"],
         ),
         (
-            "!tests|./",
-            ["pyproject.toml", "tests/demo/demo.cpp", "cpp_linter/__init__.py"],
-            ["tests/test_misc.py", "tests/demo/demo.cpp"],
+            "!src|./",
+            ["file.h", "sub/path/file.h"],
+            ["src/file.h", "src/sub/path/file.h"],
         ),
         (
             "tests/**|!tests/demo|!cpp_linter/*.py|",

--- a/tests/reviews/pr_27.diff
+++ b/tests/reviews/pr_27.diff
@@ -106,3 +106,37 @@ index 2695731..f93d012 100644
      long diff;
  
  };
+
+diff --git a/src/demo.c b/src/demo.c
+index 0c1db60..1bf553e 100644
+--- a/src/demo.c
++++ b/src/demo.c
+@@ -1,17 +1,18 @@
+ /** This is a very ugly test code (doomed to fail linting) */
+ #include "demo.hpp"
+-#include <cstdio>
+-#include <cstddef>
++#include <stdio.h>
+ 
+-// using size_t from cstddef
+-size_t dummyFunc(size_t i) { return i; }
+ 
+-int main()
+-{
+-    for (;;)
+-        break;
++
++
++int main(){
++
++    for (;;) break;
++
+ 
+     printf("Hello world!\n");
+ 
+-    return 0;
+-}
++
++
++
++    return 0;}

--- a/tests/reviews/test_pr_review.py
+++ b/tests/reviews/test_pr_review.py
@@ -157,6 +157,9 @@ def test_post_review(
             tidy_review=tidy_review,
             format_review=format_review,
             num_workers=num_workers,
+            extensions=["cpp", "hpp"],
+            tidy_ignore="",
+            format_ignore="",
         )
         if not force_approved:
             assert [note for concern in tidy_advice for note in concern.notes]

--- a/tests/reviews/test_pr_review.py
+++ b/tests/reviews/test_pr_review.py
@@ -8,6 +8,7 @@ import pytest
 
 from cpp_linter.rest_api.github_api import GithubApiClient
 from cpp_linter.clang_tools import capture_clang_tools_output
+from cpp_linter.common_fs.file_filter import FileFilter
 
 TEST_REPO = "cpp-linter/test-cpp-linter-action"
 TEST_PR = 27
@@ -136,9 +137,7 @@ def test_post_review(
 
         # run the actual test
         files = gh_client.get_list_of_changed_files(
-            extensions=["cpp", "hpp"],
-            ignored=[],
-            not_ignored=[],
+            FileFilter(extensions=["cpp", "hpp"], ignore_value="", not_ignored=[]),
             lines_changed_only=changes,
         )
         assert files

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -2,7 +2,7 @@
 
 from typing import List, Union
 import pytest
-from cpp_linter.cli import cli_arg_parser, Args
+from cpp_linter.cli import get_cli_parser, Args
 
 
 @pytest.mark.parametrize(
@@ -45,5 +45,5 @@ def test_arg_parser(
     attr_value: Union[int, str, List[str], bool, None],
 ):
     """parameterized test of specific args compared to their parsed value"""
-    args = cli_arg_parser.parse_args([f"--{arg_name}={arg_value}"], namespace=Args())
+    args = get_cli_parser().parse_args([f"--{arg_name}={arg_value}"], namespace=Args())
     assert getattr(args, attr_name) == attr_value

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -2,57 +2,7 @@
 
 from typing import List, Union
 import pytest
-from cpp_linter.cli import cli_arg_parser
-
-
-class Args:
-    """A pseudo namespace declaration. Each attribute is initialized with the
-    corresponding CLI arg's default value."""
-
-    verbosity: bool = False
-    database: str = ""
-    style: str = "llvm"
-    tidy_checks: str = (
-        "boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,"
-        "clang-analyzer-*,cppcoreguidelines-*"
-    )
-    version: str = ""
-    extensions: List[str] = [
-        "c",
-        "h",
-        "C",
-        "H",
-        "cpp",
-        "hpp",
-        "cc",
-        "hh",
-        "c++",
-        "h++",
-        "cxx",
-        "hxx",
-    ]
-    repo_root: str = "."
-    ignore: str = ".github"
-    lines_changed_only: int = 0
-    files_changed_only: bool = False
-    thread_comments: str = "false"
-    step_summary: bool = False
-    file_annotations: bool = True
-    extra_arg: List[str] = []
-    no_lgtm: bool = True
-    files: List[str] = []
-    tidy_review: bool = False
-    format_review: bool = False
-    jobs: int = 1
-    ignore_tidy: str = ""
-    ignore_format: str = ""
-
-
-def test_defaults():
-    """test default values"""
-    args = cli_arg_parser.parse_args("")
-    for key in args.__dict__.keys():
-        assert args.__dict__[key] == getattr(Args, key)
+from cpp_linter.cli import cli_arg_parser, Args
 
 
 @pytest.mark.parametrize(
@@ -95,5 +45,5 @@ def test_arg_parser(
     attr_value: Union[int, str, List[str], bool, None],
 ):
     """parameterized test of specific args compared to their parsed value"""
-    args = cli_arg_parser.parse_args([f"--{arg_name}={arg_value}"])
+    args = cli_arg_parser.parse_args([f"--{arg_name}={arg_value}"], namespace=Args())
     assert getattr(args, attr_name) == attr_value

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -44,6 +44,8 @@ class Args:
     tidy_review: bool = False
     format_review: bool = False
     jobs: int = 1
+    ignore_tidy: str = ""
+    ignore_format: str = ""
 
 
 def test_defaults():
@@ -83,6 +85,7 @@ def test_defaults():
         ("jobs", "1", "jobs", 1),
         ("jobs", "4", "jobs", 4),
         pytest.param("jobs", "x", "jobs", 0, marks=pytest.mark.xfail),
+        ("ignore-tidy", "!src|", "ignore_tidy", "!src|"),
     ],
 )
 def test_arg_parser(

--- a/tests/test_comment_length.py
+++ b/tests/test_comment_length.py
@@ -11,14 +11,13 @@ def test_comment_length_limit(tmp_path: Path):
     file_name = "tests/demo/demo.cpp"
     abs_limit = 65535
     format_checks_failed = 3000
-    files = [FileObj(file_name)] * format_checks_failed
+    file = FileObj(file_name)
     dummy_advice = FormatAdvice(file_name)
     dummy_advice.replaced_lines = [FormatReplacementLine(line_numb=1)]
-    format_advice = [dummy_advice] * format_checks_failed
+    file.format_advice = dummy_advice
+    files = [file] * format_checks_failed
     thread_comment = GithubApiClient.make_comment(
         files=files,
-        format_advice=format_advice,
-        tidy_advice=[],
         format_checks_failed=format_checks_failed,
         tidy_checks_failed=0,
         len_limit=abs_limit,
@@ -27,8 +26,6 @@ def test_comment_length_limit(tmp_path: Path):
     assert thread_comment.endswith(USER_OUTREACH)
     step_summary = GithubApiClient.make_comment(
         files=files,
-        format_advice=format_advice,
-        tidy_advice=[],
         format_checks_failed=format_checks_failed,
         tidy_checks_failed=0,
         len_limit=None,

--- a/tests/test_git_str.py
+++ b/tests/test_git_str.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 from cpp_linter.loggers import logger
+from cpp_linter.common_fs.file_filter import FileFilter
 from cpp_linter.git import parse_diff
 from cpp_linter.git.git_str import parse_diff as parse_diff_str
 
@@ -40,7 +41,9 @@ def test_pygit2_bug1260(caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.WARNING, logger=logger.name)
     # the bug in libgit2 should trigger a call to
     # cpp_linter.git_str.legacy_parse_diff()
-    files = parse_diff(diff_str, ["cpp"], [], [], 0)
+    files = parse_diff(
+        diff_str, FileFilter(extensions=["cpp"], ignore_value="", not_ignored=[]), 0
+    )
     assert caplog.messages, "this test is no longer needed; bug was fixed in pygit2"
     # if we get here test, then is satisfied
     assert not files  # no line changes means no file to focus on
@@ -48,8 +51,9 @@ def test_pygit2_bug1260(caplog: pytest.LogCaptureFixture):
 
 def test_typical_diff():
     """For coverage completeness. Also tests for files with spaces in the names."""
-    from_c = parse_diff(TYPICAL_DIFF, ["cpp"], [], [], 0)
-    from_py = parse_diff_str(TYPICAL_DIFF, ["cpp"], [], [], 0)
+    file_filter = FileFilter(extensions=["cpp"], ignore_value="", not_ignored=[])
+    from_c = parse_diff(TYPICAL_DIFF, file_filter, 0)
+    from_py = parse_diff_str(TYPICAL_DIFF, file_filter, 0)
     assert [f.serialize() for f in from_c] == [f.serialize() for f in from_py]
     for file_obj in from_c:
         # file name should have spaces
@@ -65,14 +69,18 @@ def test_binary_diff():
             "Binary files /dev/null and b/some picture.png differ",
         ]
     )
-    files = parse_diff_str(diff_str, ["cpp"], [], [], 0)
+    files = parse_diff_str(
+        diff_str, FileFilter(extensions=["cpp"], ignore_value="", not_ignored=[]), 0
+    )
     # binary files are ignored during parsing
     assert not files
 
 
 def test_ignored_diff():
     """For coverage completeness"""
-    files = parse_diff_str(TYPICAL_DIFF, ["hpp"], [], [], 0)
+    files = parse_diff_str(
+        TYPICAL_DIFF, FileFilter(extensions=["hpp"], ignore_value="", not_ignored=[]), 0
+    )
     # binary files are ignored during parsing
     assert not files
 
@@ -96,9 +104,10 @@ def test_terse_hunk_header():
             "+}",
         ]
     )
-    files = parse_diff_str(diff_str, ["cpp"], [], [], 0)
+    file_filter = FileFilter(extensions=["cpp"], ignore_value="", not_ignored=[])
+    files = parse_diff_str(diff_str, file_filter, 0)
     assert files
     assert files[0].diff_chunks == [[3, 4], [5, 7], [17, 19]]
-    git_files = parse_diff(diff_str, ["cpp"], [], [], 0)
+    git_files = parse_diff(diff_str, file_filter, 0)
     assert git_files
     assert files[0].diff_chunks == git_files[0].diff_chunks

--- a/tests/test_git_str.py
+++ b/tests/test_git_str.py
@@ -41,9 +41,7 @@ def test_pygit2_bug1260(caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.WARNING, logger=logger.name)
     # the bug in libgit2 should trigger a call to
     # cpp_linter.git_str.legacy_parse_diff()
-    files = parse_diff(
-        diff_str, FileFilter(extensions=["cpp"], ignore_value="", not_ignored=[]), 0
-    )
+    files = parse_diff(diff_str, FileFilter(extensions=["cpp"]), 0)
     assert caplog.messages, "this test is no longer needed; bug was fixed in pygit2"
     # if we get here test, then is satisfied
     assert not files  # no line changes means no file to focus on
@@ -51,7 +49,7 @@ def test_pygit2_bug1260(caplog: pytest.LogCaptureFixture):
 
 def test_typical_diff():
     """For coverage completeness. Also tests for files with spaces in the names."""
-    file_filter = FileFilter(extensions=["cpp"], ignore_value="", not_ignored=[])
+    file_filter = FileFilter(extensions=["cpp"])
     from_c = parse_diff(TYPICAL_DIFF, file_filter, 0)
     from_py = parse_diff_str(TYPICAL_DIFF, file_filter, 0)
     assert [f.serialize() for f in from_c] == [f.serialize() for f in from_py]
@@ -69,18 +67,14 @@ def test_binary_diff():
             "Binary files /dev/null and b/some picture.png differ",
         ]
     )
-    files = parse_diff_str(
-        diff_str, FileFilter(extensions=["cpp"], ignore_value="", not_ignored=[]), 0
-    )
+    files = parse_diff_str(diff_str, FileFilter(extensions=["cpp"]), 0)
     # binary files are ignored during parsing
     assert not files
 
 
 def test_ignored_diff():
     """For coverage completeness"""
-    files = parse_diff_str(
-        TYPICAL_DIFF, FileFilter(extensions=["hpp"], ignore_value="", not_ignored=[]), 0
-    )
+    files = parse_diff_str(TYPICAL_DIFF, FileFilter(extensions=["hpp"]), 0)
     # binary files are ignored during parsing
     assert not files
 
@@ -104,7 +98,7 @@ def test_terse_hunk_header():
             "+}",
         ]
     )
-    file_filter = FileFilter(extensions=["cpp"], ignore_value="", not_ignored=[])
+    file_filter = FileFilter(extensions=["cpp"])
     files = parse_diff_str(diff_str, file_filter, 0)
     assert files
     assert files[0].diff_chunks == [[3, 4], [5, 7], [17, 19]]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -75,7 +75,7 @@ def test_list_src_files(
     """List the source files in the root folder of this repo."""
     monkeypatch.chdir(Path(__file__).parent.parent.as_posix())
     caplog.set_level(logging.DEBUG, logger=logger.name)
-    file_filter = FileFilter(extensions=extensions, ignore_value="", not_ignored=[])
+    file_filter = FileFilter(extensions=extensions)
     files = file_filter.list_source_files()
     assert files
     for file in files:
@@ -142,9 +142,7 @@ def test_get_changed_files(
             text="",
         )
 
-        files = gh_client.get_list_of_changed_files(
-            FileFilter(extensions=[], ignore_value="", not_ignored=[]), 0
-        )
+        files = gh_client.get_list_of_changed_files(FileFilter(), 0)
         assert not files
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -10,11 +10,8 @@ from typing import List, cast
 import pytest
 import requests_mock
 
-from cpp_linter.common_fs import (
-    get_line_cnt_from_cols,
-    FileObj,
-    list_source_files,
-)
+from cpp_linter.common_fs import get_line_cnt_from_cols, FileObj
+from cpp_linter.common_fs.file_filter import FileFilter
 from cpp_linter.clang_tools import assemble_version_exec
 from cpp_linter.loggers import (
     logger,
@@ -78,7 +75,8 @@ def test_list_src_files(
     """List the source files in the root folder of this repo."""
     monkeypatch.chdir(Path(__file__).parent.parent.as_posix())
     caplog.set_level(logging.DEBUG, logger=logger.name)
-    files = list_source_files(extensions=extensions, ignored=[], not_ignored=[])
+    file_filter = FileFilter(extensions=extensions, ignore_value="", not_ignored=[])
+    files = file_filter.list_source_files()
     assert files
     for file in files:
         assert Path(file.name).suffix.lstrip(".") in extensions
@@ -144,7 +142,9 @@ def test_get_changed_files(
             text="",
         )
 
-        files = gh_client.get_list_of_changed_files([], [], [], 0)
+        files = gh_client.get_list_of_changed_files(
+            FileFilter(extensions=[], ignore_value="", not_ignored=[]), 0
+        )
         assert not files
 
 


### PR DESCRIPTION
satisfy ideas stated in cpp-linter/cpp-linter-action#233

This basically allows better reuse of code for filtering files. We can now filter all files (globally) and further filter files based on tool-specific patterns given by the new `--ignore-tidy` and/or `--ignore-format` options.

Any generated advice from clang tools is now stored in `FileObj` attributes. This allows better handling of advice _per file_. Previously, clang-tidy and clang-format were expected to run on all files, but this is not guaranteed now.

The collection of parsed CLI args is passed around instead of passing only relevant argument values. This keeps
- [x] functions' parameter counts down (less complexity)
- [x] functions signatures easier to maintain
- [x] less duplicated doc strings
