### PR TITLE
abstract `api_request()` with custom rate-limit headers

### DIFF
--- a/cpp_linter/__init__.py
+++ b/cpp_linter/__init__.py
@@ -2,8 +2,6 @@
 If executed from command-line, then `main()` is the entrypoint.
 """
 
-import json
-import logging
 import os
 from .common_fs import list_source_files, CACHE_PATH
 from .loggers import start_log_group, end_log_group, logger
@@ -35,11 +33,6 @@ def main():
     # change working directory
     os.chdir(args.repo_root)
     CACHE_PATH.mkdir(exist_ok=True)
-
-    if logger.getEffectiveLevel() <= logging.DEBUG:
-        start_log_group("Event json from the runner")
-        logger.debug(json.dumps(rest_api_client.event_payload))
-        end_log_group()
 
     if args.files_changed_only:
         files = rest_api_client.get_list_of_changed_files(

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -1,8 +1,12 @@
+"""This base module holds abstractions common to using REST API.
+See other modules in ``rest_api`` subpackage for detailed derivatives.
+"""
+
 from abc import ABC
 from pathlib import PurePath
 import sys
 import time
-from typing import Optional, Dict, List, Any, cast
+from typing import Optional, Dict, List, Any, cast, NamedTuple
 import requests
 from ..common_fs import FileObj
 from ..clang_tools.clang_format import FormatAdvice
@@ -17,17 +21,13 @@ USER_OUTREACH = (
 COMMENT_MARKER = "<!-- cpp linter action -->\n"
 
 
-class RateLimitHeaders:
+class RateLimitHeaders(NamedTuple):
     """A collection of HTTP response header keys that describe a REST API's rate limits.
     Each parameter corresponds to a instance attribute (see below)."""
 
-    def __init__(self, reset: str, remaining: str, retry: str) -> None:
-        #: The header key of the rate limit's reset time.
-        self.reset = reset
-        #: The header key of the rate limit's remaining attempts.
-        self.remaining = remaining
-        #: The header key of the rate limit's "backoff" time interval.
-        self.retry = retry
+    reset: str  #: The header key of the rate limit's reset time.
+    remaining: str  #: The header key of the rate limit's remaining attempts.
+    retry: str  #: The header key of the rate limit's "backoff" time interval.
 
 
 class RestApiClient(ABC):

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -319,16 +319,16 @@ class RestApiClient(ABC):
         """
         raise NotImplementedError("Must be defined in the derivative")
 
+    @staticmethod
+    def has_more_pages(response: requests.Response) -> Optional[str]:
+        """A helper function to parse a HTTP request's response headers to determine if
+        the previous REST API call is paginated.
 
-def has_more_pages(response: requests.Response) -> Optional[str]:
-    """A helper function to parse a HTTP request's response headers to determine if the
-    previous REST API call is paginated.
+        :param response: A HTTP request's response.
 
-    :param response: A HTTP request's response.
-
-    :returns: The URL of the next page if any, otherwise `None`.
-    """
-    links = response.links
-    if "next" in links and "url" in links["next"]:
-        return links["next"]["url"]
-    return None
+        :returns: The URL of the next page if any, otherwise `None`.
+        """
+        links = response.links
+        if "next" in links and "url" in links["next"]:
+            return links["next"]["url"]
+        return None

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -1,11 +1,13 @@
 from abc import ABC
 from pathlib import PurePath
+import sys
+import time
+from typing import Optional, Dict, List, Any, cast
 import requests
-from typing import Optional, Dict, List, Any
 from ..common_fs import FileObj
 from ..clang_tools.clang_format import FormatAdvice
 from ..clang_tools.clang_tidy import TidyAdvice
-from ..loggers import logger
+from ..loggers import logger, log_response_msg
 
 
 USER_OUTREACH = (
@@ -15,9 +17,45 @@ USER_OUTREACH = (
 COMMENT_MARKER = "<!-- cpp linter action -->\n"
 
 
+class RateLimitHeaders:
+    """A collection of HTTP response header keys that describe a REST API's rate limits.
+    Each parameter corresponds to a instance attribute (see below)."""
+
+    def __init__(self, reset: str, remaining: str, retry: str) -> None:
+        #: The header key of the rate limit's reset time.
+        self.reset = reset
+        #: The header key of the rate limit's remaining attempts.
+        self.remaining = remaining
+        #: The header key of the rate limit's "backoff" time interval.
+        self.retry = retry
+
+
 class RestApiClient(ABC):
-    def __init__(self) -> None:
+    """A class that describes the API used to interact with a git server's REST API.
+
+    :param rate_limit_headers: See `RateLimitHeaders` class.
+    """
+
+    def __init__(self, rate_limit_headers: RateLimitHeaders) -> None:
         self.session = requests.Session()
+
+        # The remain API requests allowed under the given token (if any).
+        self._rate_limit_remaining = -1  # -1 means unknown
+        # a counter for avoiding secondary rate limits
+        self._rate_limit_back_step = 0
+        # the rate limit reset time
+        self._rate_limit_reset: Optional[time.struct_time] = None
+        # the rate limit HTTP response header keys
+        self._rate_limit_headers = rate_limit_headers
+
+    def _rate_limit_exceeded(self):
+        logger.error("RATE LIMIT EXCEEDED!")
+        if self._rate_limit_reset is not None:
+            logger.error(
+                "Gitlab REST API rate limit resets on %s",
+                time.strftime("%d %B %Y %H:%M +0000", self._rate_limit_reset),
+            )
+        sys.exit(1)
 
     def api_request(
         self,
@@ -42,7 +80,45 @@ class RestApiClient(ABC):
         :returns:
             The HTTP request's response object.
         """
-        raise NotImplementedError("Must be defined in the derivative")
+        if self._rate_limit_back_step >= 5 or self._rate_limit_remaining == 0:
+            self._rate_limit_exceeded()
+        response = self.session.request(
+            method=method or ("GET" if data is None else "POST"),
+            url=url,
+            headers=headers,
+            data=data,
+        )
+        self._rate_limit_remaining = int(
+            response.headers.get(self._rate_limit_headers.remaining, "-1")
+        )
+        if self._rate_limit_headers.reset in response.headers:
+            self._rate_limit_reset = time.gmtime(
+                int(response.headers[self._rate_limit_headers.reset])
+            )
+        log_response_msg(response)
+        if response.status_code in [403, 429]:  # rate limit exceeded
+            # secondary rate limit handling
+            if self._rate_limit_headers.retry in response.headers:
+                wait_time = (
+                    float(
+                        cast(str, response.headers.get(self._rate_limit_headers.retry))
+                    )
+                    * self._rate_limit_back_step
+                )
+                logger.warning(
+                    "SECONDARY RATE LIMIT HIT! Backing off for %f seconds",
+                    wait_time,
+                )
+                time.sleep(wait_time)
+                self._rate_limit_back_step += 1
+                return self.api_request(url, method=method, data=data, headers=headers)
+            # primary rate limit handling
+            if self._rate_limit_remaining == 0:
+                self._rate_limit_exceeded()
+        if strict:
+            response.raise_for_status()
+        self._rate_limit_back_step = 0
+        return response
 
     def set_exit_code(
         self,
@@ -242,3 +318,17 @@ class RestApiClient(ABC):
             PR review comments using clang-format.
         """
         raise NotImplementedError("Must be defined in the derivative")
+
+
+def has_more_pages(response: requests.Response) -> Optional[str]:
+    """A helper function to parse a HTTP request's response headers to determine if the
+    previous REST API call is paginated.
+
+    :param response: A HTTP request's response.
+
+    :returns: The URL of the next page if any, otherwise `None`.
+    """
+    links = response.links
+    if "next" in links and "url" in links["next"]:
+        return links["next"]["url"]
+    return None

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -27,13 +27,7 @@ from ..clang_tools.clang_tidy import TidyAdvice, tally_tidy_advice
 from ..common_fs import FileObj, CACHE_PATH
 from ..loggers import start_log_group, logger, log_commander
 from ..git import parse_diff, get_diff
-from . import (
-    RestApiClient,
-    USER_OUTREACH,
-    COMMENT_MARKER,
-    RateLimitHeaders,
-    has_more_pages,
-)
+from . import RestApiClient, USER_OUTREACH, COMMENT_MARKER, RateLimitHeaders
 
 RATE_LIMIT_HEADERS = RateLimitHeaders(
     reset="x-ratelimit-reset",
@@ -340,7 +334,7 @@ class GithubApiClient(RestApiClient):
         next_page: Optional[str] = comments_url + f"?page={page}&per_page=100"
         while next_page:
             response = self.api_request(url=next_page)
-            next_page = has_more_pages(response)
+            next_page = self.has_more_pages(response)
             page += 1
 
             comments = cast(List[Dict[str, Any]], response.json())
@@ -521,7 +515,7 @@ class GithubApiClient(RestApiClient):
         next_page: Optional[str] = url + "?page=1&per_page=100"
         while next_page:
             response = self.api_request(url=next_page)
-            next_page = has_more_pages(response)
+            next_page = self.has_more_pages(response)
 
             reviews: List[Dict[str, Any]] = response.json()
             for review in reviews:

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -91,7 +91,7 @@ def prep_api_client(
 
     # prevent CI tests in PRs from altering the URL used in the mock tests
     monkeypatch.setenv("CI", "true")  # make fake requests using session adaptor
-    gh_client.event_payload.clear()
+    gh_client.pull_request = -1
     gh_client.event_name = "push"
 
     adapter = requests_mock.Adapter(case_sensitive=True)

--- a/tests/comments/test_comments.py
+++ b/tests/comments/test_comments.py
@@ -81,7 +81,7 @@ def test_post_feedback(
     )
 
     # patch env vars
-    event_payload = {"number": TEST_PR, "repository": {"private": False}}
+    event_payload = {"number": TEST_PR}
     event_payload_path = tmp_path / "event_payload.json"
     event_payload_path.write_text(json.dumps(event_payload), encoding="utf-8")
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_payload_path))

--- a/tests/reviews/test_pr_review.py
+++ b/tests/reviews/test_pr_review.py
@@ -84,7 +84,7 @@ def test_post_review(
 ):
     """A mock test of posting PR reviews"""
     # patch env vars
-    event_payload = {"number": TEST_PR, "repository": {"private": False}}
+    event_payload = {"number": TEST_PR}
     event_payload_path = tmp_path / "event_payload.json"
     event_payload_path.write_text(json.dumps(event_payload), encoding="utf-8")
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_payload_path))

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -128,7 +128,7 @@ def test_get_changed_files(
     for name, value in pseudo.items():
         setattr(gh_client, name, value)
     if "event_name" in pseudo and pseudo["event_name"] == "pull_request":
-        gh_client.event_payload = dict(number=19)
+        gh_client.pull_request = 19
     if not fake_runner:
         # getting a diff in CI (on a shallow checkout) fails
         # monkey patch the .git.get_diff() to return nothing


### PR DESCRIPTION
also moves `has_more_pages()` into rest_api_client.py module.

This is a small abstraction from trying to support gitlab CI (see [gitlab PR](https://gitlab.com/2bndy5/cpp-linter/-/merge_requests/7/diffs)). It posses no significant API changes.