### PR TITLE
swap file names in paginated changed files's diff

### DIFF
--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -142,8 +142,8 @@ class GithubApiClient(RestApiClient):
                     old_name = file["previous_filename"]
                 assert "patch" in file
                 file_diff = (
-                    f"diff --git a/{file_name} b/{old_name}\n"
-                    + f"--- a/{file_name}\n+++ b/{old_name}\n"
+                    f"diff --git a/{old_name} b/{file_name}\n"
+                    + f"--- a/{old_name}\n+++ b/{file_name}\n"
                     + file["patch"]
                 )
                 files.extend(parse_diff(file_diff, file_filter, lines_changed_only))


### PR DESCRIPTION
A bug-fix about changes in #116 

When getting changed files for a large diff, I noticed the generated diff from the files' individual patch had the filenames reversed. This only affects changed files that were renamed.

