### PR TITLE
feat: capture and output clang version used

### DIFF
--- a/cpp_linter/__init__.py
+++ b/cpp_linter/__init__.py
@@ -75,10 +75,10 @@ def main():
         )
     end_log_group()
 
-    capture_clang_tools_output(files=files, args=args)
+    clang_versions = capture_clang_tools_output(files=files, args=args)
 
     start_log_group("Posting comment(s)")
-    rest_api_client.post_feedback(files=files, args=args)
+    rest_api_client.post_feedback(files=files, args=args, clang_versions=clang_versions)
     end_log_group()
 
 

--- a/cpp_linter/clang_tools/__init__.py
+++ b/cpp_linter/clang_tools/__init__.py
@@ -85,12 +85,12 @@ def _capture_tool_version(cmd: str) -> str:
     version_out = subprocess.run([cmd, "--version"], capture_output=True, check=True)
     output = version_out.stdout.decode()
     matched = VERSION_PATTERN.search(output)
-    if matched is None:
+    if matched is None:  # pragma: no cover
         raise RuntimeError(
             f"Failed to get version numbers from `{cmd} --version` output"
         )
     ver = cast(str, matched.group(1))
-    logger.info("%s --version\n%s", cmd, ver)
+    logger.info("`%s --version`: %s", cmd, ver)
     return ver
 
 
@@ -115,18 +115,18 @@ def capture_clang_tools_output(files: List[FileObj], args: Args) -> ClangVersion
         format_cmd = assemble_version_exec("clang-format", args.version)
         assert format_cmd is not None, "clang-format executable was not found"
         clang_versions.format = _capture_tool_version(format_cmd)
-        tidy_filter = TidyFileFilter(
+        format_filter = FormatFileFilter(
             extensions=args.extensions,
-            ignore_value=args.ignore_tidy,
+            ignore_value=args.ignore_format,
         )
     if args.tidy_checks != "-*":
         # if all checks are disabled, then clang-tidy is skipped
         tidy_cmd = assemble_version_exec("clang-tidy", args.version)
         assert tidy_cmd is not None, "clang-tidy executable was not found"
         clang_versions.tidy = _capture_tool_version(tidy_cmd)
-        format_filter = FormatFileFilter(
+        tidy_filter = TidyFileFilter(
             extensions=args.extensions,
-            ignore_value=args.ignore_format,
+            ignore_value=args.ignore_tidy,
         )
 
     db_json: Optional[List[Dict[str, str]]] = None

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -142,6 +142,7 @@ class TidyAdvice(PatchMixin):
             return False
 
         # now check for clang-tidy warnings with no fixes applied
+        assert isinstance(review_comments.tool_total["clang-tidy"], int)
         for note in self.notes:
             if not note.applied_fixes:  # if no fix was applied
                 line_numb = int(note.line)

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -133,7 +133,10 @@ class TidyAdvice(PatchMixin):
 
         def _has_related_suggestion(suggestion: Suggestion) -> bool:
             for known in review_comments.suggestions:
-                if known.line_end >= suggestion.line_end >= known.line_start:
+                if (
+                    known.file_name == suggestion.file_name
+                    and known.line_end >= suggestion.line_end >= known.line_start
+                ):
                     known.comment += f"\n{suggestion.comment}"
                     return True
             return False

--- a/cpp_linter/clang_tools/patcher.py
+++ b/cpp_linter/clang_tools/patcher.py
@@ -91,8 +91,8 @@ class ReviewComments:
         """Serialize this object into a summary and list of comments compatible
         with Github's REST API.
 
-        :param tidy_versions: The version numbers of the clang-tidy used.
-        :param format_versions: The version numbers of the clang-format used.
+        :param tidy_version: The version numbers of the clang-tidy used.
+        :param format_version: The version numbers of the clang-format used.
 
         :returns: The returned tuple contains a brief summary (at index ``0``)
             that contains markdown text describing the summary of the review

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -12,6 +12,7 @@ from ..common_fs import FileObj
 from ..common_fs.file_filter import FileFilter
 from ..cli import Args
 from ..loggers import logger, log_response_msg
+from ..clang_tools import ClangVersions
 
 
 USER_OUTREACH = (
@@ -168,6 +169,7 @@ class RestApiClient(ABC):
         files: List[FileObj],
         format_checks_failed: int,
         tidy_checks_failed: int,
+        clang_versions: ClangVersions,
         len_limit: Optional[int] = None,
     ) -> str:
         """Make an MarkDown comment from the given advice. Also returns a count of
@@ -176,6 +178,7 @@ class RestApiClient(ABC):
         :param files: A list of objects, each describing a file's information.
         :param format_checks_failed: The amount of clang-format checks that have failed.
         :param tidy_checks_failed: The amount of clang-tidy checks that have failed.
+        :param clang_versions: The versions of the clang tools used.
         :param len_limit: The length limit of the comment generated.
 
         :Returns: The markdown comment as a `str`
@@ -199,12 +202,14 @@ class RestApiClient(ABC):
                     files=files,
                     checks_failed=format_checks_failed,
                     len_limit=len_limit,
+                    version=clang_versions.format,
                 )
             if tidy_checks_failed:
                 comment += RestApiClient._make_tidy_comment(
                     files=files,
                     checks_failed=tidy_checks_failed,
                     len_limit=adjust_limit(limit=len_limit, text=comment),
+                    version=clang_versions.tidy,
                 )
         else:
             prefix = ":heavy_check_mark:\nNo problems need attention."
@@ -215,9 +220,12 @@ class RestApiClient(ABC):
         files: List[FileObj],
         checks_failed: int,
         len_limit: Optional[int] = None,
+        version: Optional[str] = None,
     ) -> str:
         """make a comment describing clang-format errors"""
-        comment = "\n<details><summary>clang-format reports: <strong>"
+        comment = "\n<details><summary>clang-format{} reports: <strong>".format(
+            "" if version is None else f" (v{version})"
+        )
         comment += f"{checks_failed} file(s) not formatted</strong></summary>\n\n"
         closer = "\n</details>"
         checks_failed = 0
@@ -238,9 +246,12 @@ class RestApiClient(ABC):
         files: List[FileObj],
         checks_failed: int,
         len_limit: Optional[int] = None,
+        version: Optional[str] = None,
     ) -> str:
         """make a comment describing clang-tidy errors"""
-        comment = "\n<details><summary>clang-tidy reports: <strong>"
+        comment = "\n<details><summary>clang-tidy{} reports: <strong>".format(
+            "" if version is None else f" (v{version})"
+        )
         comment += f"{checks_failed} concern(s)</strong></summary>\n\n"
         closer = "\n</details>"
         for file_obj in files:
@@ -276,6 +287,7 @@ class RestApiClient(ABC):
         self,
         files: List[FileObj],
         args: Args,
+        clang_versions: ClangVersions,
     ):
         """Post action's results using REST API.
 

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -293,6 +293,7 @@ class RestApiClient(ABC):
 
         :param files: A list of objects, each describing a file's information.
         :param args: A namespace of arguments parsed from the :doc:`CLI <../cli_args>`.
+        :param clang_versions: The version of the clang tools used.
         """
         raise NotImplementedError("Must be defined in the derivative")
 

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -257,6 +257,7 @@ class GithubApiClient(RestApiClient):
                 format_review=args.format_review,
                 no_lgtm=args.no_lgtm,
                 passive_reviews=args.passive_reviews,
+                clang_versions=clang_versions,
             )
 
     def make_annotations(
@@ -392,6 +393,7 @@ class GithubApiClient(RestApiClient):
         format_review: bool,
         no_lgtm: bool,
         passive_reviews: bool,
+        clang_versions: ClangVersions,
     ):
         url = f"{self.api_url}/repos/{self.repo}/pulls/{self.pull_request}"
         response = self.api_request(url=url)
@@ -423,7 +425,11 @@ class GithubApiClient(RestApiClient):
                 summary_only=summary_only,
                 review_comments=review_comments,
             )
-        (summary, comments) = review_comments.serialize_to_github_payload()
+        (summary, comments) = review_comments.serialize_to_github_payload(
+            # avoid circular imports by passing primitive types
+            tidy_version=clang_versions.tidy,
+            format_version=clang_versions.format,
+        )
         if not summary_only:
             payload_comments.extend(comments)
         body += summary

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -433,7 +433,7 @@ class GithubApiClient(RestApiClient):
         if not summary_only:
             payload_comments.extend(comments)
         body += summary
-        if sum(review_comments.tool_total.values()):
+        if sum([x for x in review_comments.tool_total.values() if isinstance(x, int)]):
             event = "REQUEST_CHANGES"
         else:
             if no_lgtm:
@@ -467,6 +467,10 @@ class GithubApiClient(RestApiClient):
         :param review_comments: An object (passed by reference) that is used to store
             the results.
         """
+        if tidy_tool:
+            review_comments.tool_total["clang-tidy"] = 0
+        else:
+            review_comments.tool_total["clang-format"] = 0
         for file_obj in files:
             tool_advice: Optional[PatchMixin]
             if tidy_tool:

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -25,6 +25,7 @@ from ..clang_tools.clang_format import (
 )
 from ..clang_tools.clang_tidy import tally_tidy_advice
 from ..clang_tools.patcher import ReviewComments, PatchMixin
+from ..clang_tools import ClangVersions
 from ..cli import Args
 from ..loggers import logger, log_commander
 from ..git import parse_diff, get_diff
@@ -187,6 +188,7 @@ class GithubApiClient(RestApiClient):
         self,
         files: List[FileObj],
         args: Args,
+        clang_versions: ClangVersions,
     ):
         format_checks_failed = tally_format_advice(files)
         tidy_checks_failed = tally_tidy_advice(files)
@@ -198,6 +200,7 @@ class GithubApiClient(RestApiClient):
                 files=files,
                 format_checks_failed=format_checks_failed,
                 tidy_checks_failed=tidy_checks_failed,
+                clang_versions=clang_versions,
                 len_limit=None,
             )
             with open(environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
@@ -225,6 +228,7 @@ class GithubApiClient(RestApiClient):
                     files=files,
                     format_checks_failed=format_checks_failed,
                     tidy_checks_failed=tidy_checks_failed,
+                    clang_versions=clang_versions,
                     len_limit=65535,
                 )
 

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -467,10 +467,8 @@ class GithubApiClient(RestApiClient):
         :param review_comments: An object (passed by reference) that is used to store
             the results.
         """
-        if tidy_tool:
-            review_comments.tool_total["clang-tidy"] = 0
-        else:
-            review_comments.tool_total["clang-format"] = 0
+        tool_name = "clang-tidy" if tidy_tool else "clang-format"
+        review_comments.tool_total[tool_name] = 0
         for file_obj in files:
             tool_advice: Optional[PatchMixin]
             if tidy_tool:

--- a/tests/capture_tools_output/test_database_path.py
+++ b/tests/capture_tools_output/test_database_path.py
@@ -96,7 +96,7 @@ def test_ninja_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     args.lines_changed_only = 0  # analyze complete file
 
     # run clang-tidy and verify paths of project files were matched with database paths
-    capture_clang_tools_output(files, args=args)
+    clang_versions = capture_clang_tools_output(files, args=args)
     found_project_file = False
     for concern in [a.tidy_advice for a in files if a.tidy_advice]:
         for note in concern.notes:
@@ -112,6 +112,7 @@ def test_ninja_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         files=files,
         tidy_checks_failed=tidy_checks_failed,
         format_checks_failed=format_checks_failed,
+        clang_versions=clang_versions,
     )
 
     assert tidy_checks_failed

--- a/tests/capture_tools_output/test_database_path.py
+++ b/tests/capture_tools_output/test_database_path.py
@@ -11,7 +11,7 @@ import pytest
 from cpp_linter.loggers import logger
 from cpp_linter.common_fs import FileObj, CACHE_PATH
 from cpp_linter.rest_api.github_api import GithubApiClient
-from cpp_linter.clang_tools import capture_clang_tools_output
+from cpp_linter.clang_tools import ClangVersions, capture_clang_tools_output
 from cpp_linter.clang_tools.clang_format import tally_format_advice
 from cpp_linter.clang_tools.clang_tidy import tally_tidy_advice
 from cpp_linter.cli import Args
@@ -96,7 +96,7 @@ def test_ninja_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     args.lines_changed_only = 0  # analyze complete file
 
     # run clang-tidy and verify paths of project files were matched with database paths
-    clang_versions = capture_clang_tools_output(files, args=args)
+    clang_versions: ClangVersions = capture_clang_tools_output(files, args=args)
     found_project_file = False
     for concern in [a.tidy_advice for a in files if a.tidy_advice]:
         for note in concern.notes:

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -16,7 +16,7 @@ import requests_mock
 
 from cpp_linter.common_fs import FileObj, CACHE_PATH
 from cpp_linter.git import parse_diff, get_diff
-from cpp_linter.clang_tools import capture_clang_tools_output
+from cpp_linter.clang_tools import capture_clang_tools_output, ClangVersions
 from cpp_linter.clang_tools.clang_format import tally_format_advice
 from cpp_linter.clang_tools.clang_tidy import tally_tidy_advice
 from cpp_linter.loggers import log_commander, logger
@@ -67,10 +67,14 @@ def make_comment(
 ):
     format_checks_failed = tally_format_advice(files)
     tidy_checks_failed = tally_tidy_advice(files)
+    clang_versions = ClangVersions()
+    clang_versions.format = "x.y.z"
+    clang_versions.tidy = "x.y.z"
     comment = GithubApiClient.make_comment(
         files=files,
         tidy_checks_failed=tidy_checks_failed,
         format_checks_failed=format_checks_failed,
+        clang_versions=clang_versions,
     )
     return comment, format_checks_failed, tidy_checks_failed
 

--- a/tests/comments/test_comments.py
+++ b/tests/comments/test_comments.py
@@ -66,7 +66,7 @@ def test_post_feedback(
     args.thread_comments = thread_comments
     args.step_summary = thread_comments == "update" and not no_lgtm
     args.file_annotations = thread_comments == "update" and no_lgtm
-    capture_clang_tools_output(files, args=args)
+    clang_versions = capture_clang_tools_output(files, args=args)
     # add a non project file to tidy_advice to intentionally cover a log.debug()
     for file in files:
         if file.tidy_advice:
@@ -169,4 +169,4 @@ def test_post_feedback(
         # to get debug files saved to test workspace folders: enable logger verbosity
         caplog.set_level(logging.DEBUG, logger=logger.name)
 
-        gh_client.post_feedback(files, args)
+        gh_client.post_feedback(files, args, clang_versions)

--- a/tests/reviews/test_pr_review.py
+++ b/tests/reviews/test_pr_review.py
@@ -154,7 +154,7 @@ def test_post_review(
         if not tidy_review:
             args.tidy_checks = "-*"
         args.version = environ.get("CLANG_VERSION", "16")
-        args.style = "file" if format_review else ""
+        args.style = "file"
         args.extensions = extensions
         args.ignore_tidy = "*.c"
         args.ignore_format = "*.c"
@@ -175,10 +175,7 @@ def test_post_review(
                 assert tidy_advice and len(tidy_advice) <= len(files)
             else:
                 assert not tidy_advice
-            if format_review:
-                assert format_advice and len(format_advice) <= len(files)
-            else:
-                assert not format_advice
+            assert format_advice and len(format_advice) <= len(files)
 
         # simulate draft PR by changing the request response
         cache_pr_response = (cache_path / f"pr_{TEST_PR}.json").read_text(

--- a/tests/reviews/test_pr_review.py
+++ b/tests/reviews/test_pr_review.py
@@ -170,7 +170,7 @@ def test_post_review(
         args.file_annotations = False
         args.passive_reviews = is_passive
 
-        capture_clang_tools_output(files, args=args)
+        clang_versions = capture_clang_tools_output(files, args=args)
         if not force_approved:
             format_advice = list(filter(lambda x: x.format_advice is not None, files))
             tidy_advice = list(filter(lambda x: x.tidy_advice is not None, files))
@@ -194,7 +194,7 @@ def test_post_review(
             headers={"Accept": "application/vnd.github.text+json"},
             text=cache_pr_response,
         )
-        gh_client.post_feedback(files, args)
+        gh_client.post_feedback(files, args, clang_versions)
 
         # inspect the review payload for correctness
         last_request = mock.last_request

--- a/tests/test_comment_length.py
+++ b/tests/test_comment_length.py
@@ -16,14 +16,14 @@ def test_comment_length_limit(tmp_path: Path):
     dummy_advice = FormatAdvice(file_name)
     dummy_advice.replaced_lines = [FormatReplacementLine(line_numb=1)]
     file.format_advice = dummy_advice
-    versions = ClangVersions()
-    versions.format = "x.y.z"
+    clang_versions = ClangVersions()
+    clang_versions.format = "x.y.z"
     files = [file] * format_checks_failed
     thread_comment = GithubApiClient.make_comment(
         files=files,
         format_checks_failed=format_checks_failed,
         tidy_checks_failed=0,
-        clang_versions=versions,
+        clang_versions=clang_versions,
         len_limit=abs_limit,
     )
     assert len(thread_comment) < abs_limit
@@ -32,7 +32,7 @@ def test_comment_length_limit(tmp_path: Path):
         files=files,
         format_checks_failed=format_checks_failed,
         tidy_checks_failed=0,
-        clang_versions=versions,
+        clang_versions=clang_versions,
         len_limit=None,
     )
     assert len(step_summary) != len(thread_comment)

--- a/tests/test_comment_length.py
+++ b/tests/test_comment_length.py
@@ -3,6 +3,7 @@ from cpp_linter.rest_api.github_api import GithubApiClient
 from cpp_linter.rest_api import USER_OUTREACH
 from cpp_linter.clang_tools.clang_format import FormatAdvice, FormatReplacementLine
 from cpp_linter.common_fs import FileObj
+from cpp_linter.clang_tools import ClangVersions
 
 
 def test_comment_length_limit(tmp_path: Path):
@@ -15,11 +16,14 @@ def test_comment_length_limit(tmp_path: Path):
     dummy_advice = FormatAdvice(file_name)
     dummy_advice.replaced_lines = [FormatReplacementLine(line_numb=1)]
     file.format_advice = dummy_advice
+    versions = ClangVersions()
+    versions.format = "x.y.z"
     files = [file] * format_checks_failed
     thread_comment = GithubApiClient.make_comment(
         files=files,
         format_checks_failed=format_checks_failed,
         tidy_checks_failed=0,
+        clang_versions=versions,
         len_limit=abs_limit,
     )
     assert len(thread_comment) < abs_limit
@@ -28,6 +32,7 @@ def test_comment_length_limit(tmp_path: Path):
         files=files,
         format_checks_failed=format_checks_failed,
         tidy_checks_failed=0,
+        clang_versions=versions,
         len_limit=None,
     )
     assert len(step_summary) != len(thread_comment)


### PR DESCRIPTION
This idea was brought up in discussion #123

Shows the clang tools' version number which was used to the generated the feedback.
Affects thread-comments, step-summary, and PR review summary.

I also fixed some errors that I noticed when verifying test results:
1. filtering files per tool was not working because the file filters were assigned backwards; `ignore-tidy` was used for clang-format and `ignore-format` was used for clang-tidy.
2. merging suggestions in PR review was not checking that the file name was an exact match. This really only affected our tests because the demo.cpp file is copied twice into the test workspace (once as a `.cpp` file and again as a  `.c` file).
3. A PR review summary would state that nothing was reported from a tool that was not set to provide PR review suggestions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced feedback mechanism now includes clang tool version information in comments and reports.
	- New class `ClangVersions` added to encapsulate version details for clang tools.

- **Bug Fixes**
	- Improved suggestion handling to ensure correct association with respective files.
	- Adjusted logic for merging similar suggestions based on file names.
	- Streamlined handling of tidy checks in the review process.

- **Documentation**
	- Updated tests to reflect changes in clang output handling and feedback posting processes.

- **Chores**
	- Refactored various methods to accommodate new parameters for clang versions, improving overall clarity and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->