### PR TITLE
fix: enhance parsing paginated diffs

### DIFF
--- a/cpp_linter/loggers.py
+++ b/cpp_linter/loggers.py
@@ -12,7 +12,7 @@ try:  # pragma: no cover
 
     logging.basicConfig(
         format="%(name)s: %(message)s",
-        handlers=[RichHandler(show_time=False)],
+        handlers=[RichHandler(show_time=False, show_path=False)],
     )
 
 except ImportError:  # pragma: no cover

--- a/cpp_linter/rest_api/__init__.py
+++ b/cpp_linter/rest_api/__init__.py
@@ -40,6 +40,9 @@ class RestApiClient(ABC):
     def __init__(self, rate_limit_headers: RateLimitHeaders) -> None:
         self.session = requests.Session()
 
+        #: The brand name of the git server that provides the REST API.
+        self._name: str = "Generic"
+
         # The remain API requests allowed under the given token (if any).
         self._rate_limit_remaining = -1  # -1 means unknown
         # a counter for avoiding secondary rate limits
@@ -53,7 +56,8 @@ class RestApiClient(ABC):
         logger.error("RATE LIMIT EXCEEDED!")
         if self._rate_limit_reset is not None:
             logger.error(
-                "Gitlab REST API rate limit resets on %s",
+                "%s REST API rate limit resets on %s",
+                self._name,
                 time.strftime("%d %B %Y %H:%M +0000", self._rate_limit_reset),
             )
         sys.exit(1)

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -139,7 +139,9 @@ class GithubApiClient(RestApiClient):
                 try:
                     file_name = file["filename"]
                 except KeyError as exc:  # pragma: no cover
-                    logger.critical("file name unknown")
+                    logger.error(
+                        f"Missing 'filename' key in file:\n{json.dumps(file, indent=2)}"
+                    )
                     raise exc
                 if not file_filter.is_source_or_ignored(file_name):
                     continue
@@ -151,9 +153,9 @@ class GithubApiClient(RestApiClient):
                 if "patch" not in file:
                     if lines_changed_only > 0:
                         # diff info is needed for further operations
-                        raise KeyError(
-                            f"{file_name} has no patch info"
-                        )  # pragma: no cover
+                        raise KeyError(  # pragma: no cover
+                            f"{file_name} has no patch info:\n{json.dumps(file, indent=2)}"
+                        )
                     elif (
                         cast(int, file.get("changes", 0)) == 0
                     ):  # in case files-changed-only is true

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -46,6 +46,8 @@ class GithubApiClient(RestApiClient):
         # create default headers to be used for all HTTP requests
         self.session.headers.update(self.make_headers())
 
+        self._name = "GitHub"
+
         #: The base domain for the REST API
         self.api_url = environ.get("GITHUB_API_URL", "https://api.github.com")
         #: The ``owner``/``repository`` name.
@@ -134,18 +136,35 @@ class GithubApiClient(RestApiClient):
             else:
                 file_list = response.json()["files"]
             for file in file_list:
-                assert "filename" in file
-                file_name = file["filename"]
+                try:
+                    file_name = file["filename"]
+                except KeyError as exc:  # pragma: no cover
+                    logger.critical("file name unknown")
+                    raise exc
                 if not file_filter.is_source_or_ignored(file_name):
                     continue
+                if lines_changed_only > 0 and cast(int, file.get("changes", 0)) == 0:
+                    continue  # also prevents KeyError below when patch is not provided
                 old_name = file_name
                 if "previous_filename" in file:
                     old_name = file["previous_filename"]
-                assert "patch" in file
+                if "patch" not in file:
+                    if lines_changed_only > 0:
+                        # diff info is needed for further operations
+                        raise KeyError(
+                            f"{file_name} has no patch info"
+                        )  # pragma: no cover
+                    elif (
+                        cast(int, file.get("changes", 0)) == 0
+                    ):  # in case files-changed-only is true
+                        # file was likely renamed without source changes
+                        files.append(FileObj(file_name))  # scan entire file instead
+                        continue
                 file_diff = (
                     f"diff --git a/{old_name} b/{file_name}\n"
                     + f"--- a/{old_name}\n+++ b/{file_name}\n"
                     + file["patch"]
+                    + "\n"
                 )
                 files.extend(parse_diff(file_diff, file_filter, lines_changed_only))
         return files

--- a/tests/list_changes/pull_request_files_pg2.json
+++ b/tests/list_changes/pull_request_files_pg2.json
@@ -10,5 +10,14 @@
         "raw_url": "https://github.com/cpp-linter/test-cpp-linter-action/raw/635a9c57bdcca07b99ddef52c2640337c50280b1/src%2Fdemo.hpp",
         "contents_url": "https://api.github.com/repos/cpp-linter/test-cpp-linter-action/contents/src%2Fdemo.hpp?ref=635a9c57bdcca07b99ddef52c2640337c50280b1",
         "patch": "@@ -5,12 +5,10 @@\n class Dummy {\n     char* useless;\n     int numb;\n+    Dummy() :numb(0), useless(\"\\0\"){}\n \n     public:\n-    void *not_usefull(char *str){\n-        useless = str;\n-        return 0;\n-    }\n+    void *not_useful(char *str){useless = str;}\n };\n \n \n@@ -28,14 +26,11 @@ class Dummy {\n \n \n \n-\n-\n-\n-\n \n \n struct LongDiff\n {\n+\n     long diff;\n \n };"
+    },
+    {
+      "sha": "17694f6803e9efd8cdceda06ea12c266793abacb",
+      "filename": "include/test/tree.hpp",
+      "status": "renamed",
+      "additions": 0,
+      "deletions": 0,
+      "changes": 0,
+      "previous_filename": "include/test-tree.hpp"
     }
 ]

--- a/tests/list_changes/push_files_pg2.json
+++ b/tests/list_changes/push_files_pg2.json
@@ -11,6 +11,15 @@
       "raw_url": "https://github.com/cpp-linter/test-cpp-linter-action/raw/635a9c57bdcca07b99ddef52c2640337c50280b1/src%2Fdemo.hpp",
       "contents_url": "https://api.github.com/repos/cpp-linter/test-cpp-linter-action/contents/src%2Fdemo.hpp?ref=635a9c57bdcca07b99ddef52c2640337c50280b1",
       "patch": "@@ -5,12 +5,10 @@\n class Dummy {\n     char* useless;\n     int numb;\n+    Dummy() :numb(0), useless(\"\\0\"){}\n \n     public:\n-    void *not_usefull(char *str){\n-        useless = str;\n-        return 0;\n-    }\n+    void *not_useful(char *str){useless = str;}\n };\n \n \n@@ -28,14 +26,11 @@ class Dummy {\n \n \n \n-\n-\n-\n-\n \n \n struct LongDiff\n {\n+\n     long diff;\n \n };"
+    },
+    {
+      "sha": "17694f6803e9efd8cdceda06ea12c266793abacb",
+      "filename": "include/test/tree.hpp",
+      "status": "renamed",
+      "additions": 0,
+      "deletions": 0,
+      "changes": 0,
+      "previous_filename": "include/test-tree.hpp"
     }
   ]
 }


### PR DESCRIPTION
resolves cpp-liner/cpp-linter-action#274

- fixes libgit2 diff parsing errors in paginated responses about changed files' diff.
- allows renamed files to be scanned entirely when the source file's content has not changed (when using paginated responses)
- add tests, but ignores coverage for critical errors (like malformed JSON responses)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging configuration to suppress file path display.
	- Introduced a new private attribute for the REST API client to hold the git server name, improving logging clarity.
	- Updated GitHub API client with better error handling and logging for file changes.
	- Added a constructor and updated method names in demo files for improved clarity.

- **Bug Fixes**
	- Improved error handling in the GitHub API client for missing keys, ensuring more robust functionality.

- **Documentation**
	- Updated test cases to include a new parameter for controlling line change considerations when retrieving changed files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->