### PR TITLE
Fix tidy review write conflicts

### DIFF
--- a/cpp_linter/clang_tools/__init__.py
+++ b/cpp_linter/clang_tools/__init__.py
@@ -46,6 +46,18 @@ def _run_on_single_file(
 ) -> Tuple[str, str, Optional[TidyAdvice], Optional[FormatAdvice]]:
     log_stream = worker_log_init(log_lvl)
 
+    format_advice = None
+    if format_cmd is not None and (
+        format_filter is None or format_filter.is_source_or_ignored(file.name)
+    ):
+        format_advice = run_clang_format(
+            command=format_cmd,
+            file_obj=file,
+            style=args.style,
+            lines_changed_only=args.lines_changed_only,
+            format_review=args.format_review,
+        )
+
     tidy_note = None
     if tidy_cmd is not None and (
         tidy_filter is None or tidy_filter.is_source_or_ignored(file.name)
@@ -60,18 +72,6 @@ def _run_on_single_file(
             db_json=db_json,
             tidy_review=args.tidy_review,
             style=args.style,
-        )
-
-    format_advice = None
-    if format_cmd is not None and (
-        format_filter is None or format_filter.is_source_or_ignored(file.name)
-    ):
-        format_advice = run_clang_format(
-            command=format_cmd,
-            file_obj=file,
-            style=args.style,
-            lines_changed_only=args.lines_changed_only,
-            format_review=args.format_review,
         )
 
     return file.name, log_stream.getvalue(), tidy_note, format_advice

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -289,7 +289,7 @@ def run_clang_tidy(
                 exception = exc
         if not success:  # pragma: no cover
             logger.error(
-                "Failed to write back contents of file: %s.%s)",
+                "Failed to write back contents of file: %s.%s",
                 filename,
                 " timeout."
                 if not exception

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -261,7 +261,7 @@ def run_clang_tidy(
     advice = parse_tidy_output(results.stdout.decode(), database=db_json)
 
     if tidy_review:
-        timeout = time.monotonic_ns() + 1000000
+        timeout = time.monotonic_ns() + 1000000000
         # wait 1s for file to become accessible
         success = False
         exception = None
@@ -269,16 +269,16 @@ def run_clang_tidy(
             try:
                 with open(filename, "r+b") as src:
                     # wait 1s for file to become readable
-                    read_timeout = time.monotonic_ns() + 1000000
+                    read_timeout = time.monotonic_ns() + 1000000000
                     while not src.readable() and time.monotonic_ns() < read_timeout:
                         pass  # pragma: no cover
                     if src.readable():
                         advice.patched = b"".join(src.readlines())
-                        src.seek(os.SEEK_SET)  # back to start of file
+                        src.seek(0)  # back to start of file
                     else:  # pragma: no cover
                         continue  # we need those changes before overwriting them
                     # wait 1s for file to become writable
-                    write_timeout = time.monotonic_ns() + 1000000
+                    write_timeout = time.monotonic_ns() + 1000000000
                     while not src.writable() and time.monotonic_ns() < write_timeout:
                         pass  # pragma: no cover
                     if src.writable():

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -287,7 +287,7 @@ def run_clang_tidy(
                 break
             except OSError as exc:  # pragma: no cover
                 exception = exc
-        if not success:
+        if not success:  # pragma: no cover
             logger.error(
                 "Failed to write back contents of file: %s.%s)",
                 filename,

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -282,7 +282,7 @@ def run_clang_tidy(
                     while not src.writable() and time.monotonic_ns() < write_timeout:
                         pass  # pragma: no cover
                     if src.writable():
-                        src.writelines([original_buf])
+                        src.write(original_buf)
                         success = True
                 break
             except OSError as exc:  # pragma: no cover

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -270,23 +270,23 @@ def run_clang_tidy(
                 # wait 1s for file to become readable
                 read_timeout = time.monotonic_ns() + 1000000
                 while not src.readable() and time.monotonic_ns() < read_timeout:
-                    pass
+                    pass  # pragma: no cover
                 advice.patched = b"".join(src.readlines())
                 src.seek(os.SEEK_SET)  # back to start of file
                 # wait 1s for file to become writable
                 write_timeout = time.monotonic_ns() + 1000000
                 while not src.writable() and time.monotonic_ns() < write_timeout:
-                    pass
+                    pass  # pragma: no cover
                 src.writelines([original_buf])
                 src.close()
                 success = True
                 break
-            except OSError:
+            except OSError:  # pragma: no cover
                 if time.monotonic_ns() < timeout:
                     pass
                 else:
                     break
-        if not success:
+        if not success:  # pragma: no cover
             logger.error("Failed to write back contents of file: %s", filename)
 
     return advice

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -287,7 +287,7 @@ def run_clang_tidy(
                 else:
                     break
         if not success:
-            logger.logError("Failed to write back contents of file: %s", filename)
+            logger.error("Failed to write back contents of file: %s", filename)
 
     return advice
 


### PR DESCRIPTION
This fixes write failures when writing back the unmodified contents of files modified by clang-tidy.

Closes #129 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for running clang-tidy with improved error handling during file operations.
	- Implemented a timeout mechanism for file accessibility checks.

- **Bug Fixes**
	- Improved handling of file buffers to ensure the most recent changes are captured before processing.

- **Refactor**
	- Organized the flow of execution in the `_run_on_single_file` function for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->