### PR TITLE
Hide review comments and resolve or delete review conversations

### DIFF
--- a/cpp_linter/clang_tools/patcher.py
+++ b/cpp_linter/clang_tools/patcher.py
@@ -153,28 +153,27 @@ class ReviewComments:
 
     def remove_reused_suggestions(self, existing_review_comments: List[Suggestion]):
         """Remove any reused ``Suggestion`` from the internal list and update counts"""
-        if len(existing_review_comments):
-            review_comments_suggestions = self.suggestions
-            self.suggestions = []
-            clang_tidy_comments = 0
-            clang_format_comments = 0
-            for suggestion in review_comments_suggestions:
-                if suggestion not in existing_review_comments:
-                    clang_tidy_comments += suggestion.comment.count("### clang-tidy")
-                    clang_format_comments += suggestion.comment.count(
-                        "### clang-format"
-                    )
-                    self.suggestions.append(suggestion)
-            if clang_tidy_comments > 0:
-                self.tool_reused["clang-tidy"] = (
-                    self.tool_total["clang-tidy"] - clang_tidy_comments
-                )
-                self.tool_total["clang-tidy"] = clang_tidy_comments
-            if clang_format_comments > 0:
-                self.tool_reused["clang-format"] = (
-                    self.tool_total["clang-format"] - clang_format_comments
-                )
-                self.tool_total["clang-format"] = clang_format_comments
+        if not existing_review_comments:
+            return
+        review_comments_suggestions = self.suggestions
+        self.suggestions = []
+        clang_tidy_comments = 0
+        clang_format_comments = 0
+        for suggestion in review_comments_suggestions:
+            if suggestion not in existing_review_comments:
+                clang_tidy_comments += suggestion.comment.count("### clang-tidy")
+                clang_format_comments += suggestion.comment.count("### clang-format")
+                self.suggestions.append(suggestion)
+        if clang_tidy_comments > 0 and self.tool_total["clang-tidy"] is not None:
+            self.tool_reused["clang-tidy"] = (
+                self.tool_total["clang-tidy"] - clang_tidy_comments
+            )
+            self.tool_total["clang-tidy"] = clang_tidy_comments
+        if clang_format_comments > 0 and self.tool_total["clang-format"] is not None:
+            self.tool_reused["clang-format"] = (
+                self.tool_total["clang-format"] - clang_format_comments
+            )
+            self.tool_total["clang-format"] = clang_format_comments
 
 
 class PatchMixin(ABC):

--- a/cpp_linter/clang_tools/patcher.py
+++ b/cpp_linter/clang_tools/patcher.py
@@ -72,6 +72,12 @@ class ReviewComments:
         """The full patch of all the suggestions (including those that will not
         fit within the diff)"""
 
+        self.tool_reused: Dict[str, int] = {
+            "clang-tidy": 0,
+            "clang-format": 0,
+        }
+        """The total number of reused concerns from previous reviews."""
+
     def merge_similar_suggestion(self, suggestion: Suggestion) -> bool:
         """Merge a given ``suggestion`` into a similar `Suggestion`
 
@@ -111,10 +117,10 @@ class ReviewComments:
         posted_tool_advice = {"clang-tidy": 0, "clang-format": 0}
         for comment in self.suggestions:
             comments.append(comment.serialize_to_github_payload())
-            if "### clang-format" in comment.comment:
-                posted_tool_advice["clang-format"] += 1
-            if "### clang-tidy" in comment.comment:
-                posted_tool_advice["clang-tidy"] += 1
+            posted_tool_advice["clang-tidy"] += comment.comment.count("### clang-tidy")
+            posted_tool_advice["clang-format"] += comment.comment.count(
+                "### clang-format"
+            )
 
         for tool_name in ("clang-tidy", "clang-format"):
             tool_version = tidy_version
@@ -123,15 +129,18 @@ class ReviewComments:
             if tool_version is None or self.tool_total[tool_name] is None:
                 continue  # if tool wasn't used
             summary += f"### Used {tool_name} v{tool_version}\n\n"
-            if (
-                len(comments)
-                and posted_tool_advice[tool_name] != self.tool_total[tool_name]
+            if len(comments) and (
+                posted_tool_advice[tool_name] != self.tool_total[tool_name]
+                or self.tool_reused[tool_name] != 0
             ):
                 summary += (
                     f"Only {posted_tool_advice[tool_name]} out of "
                     + f"{self.tool_total[tool_name]} {tool_name}"
-                    + " concerns fit within this pull request's diff.\n"
+                    + " new concerns fit within this pull request's diff."
                 )
+                if self.tool_reused[tool_name] != 0:
+                    summary += f" {self.tool_reused[tool_name]} concerns were suppressed as duplicates."
+                summary += "\n"
             if self.full_patch[tool_name]:
                 summary += (
                     f"\n<details><summary>Click here for the full {tool_name} patch"
@@ -141,6 +150,31 @@ class ReviewComments:
             elif not self.tool_total[tool_name]:
                 summary += f"No concerns from {tool_name}.\n"
         return (summary, comments)
+
+    def remove_reused_suggestions(self, existing_review_comments: List[Suggestion]):
+        """Remove any reused ``Suggestion`` from the internal list and update counts"""
+        if len(existing_review_comments):
+            review_comments_suggestions = self.suggestions
+            self.suggestions = []
+            clang_tidy_comments = 0
+            clang_format_comments = 0
+            for suggestion in review_comments_suggestions:
+                if suggestion not in existing_review_comments:
+                    clang_tidy_comments += suggestion.comment.count("### clang-tidy")
+                    clang_format_comments += suggestion.comment.count(
+                        "### clang-format"
+                    )
+                    self.suggestions.append(suggestion)
+            if clang_tidy_comments > 0:
+                self.tool_reused["clang-tidy"] = (
+                    self.tool_total["clang-tidy"] - clang_tidy_comments
+                )
+                self.tool_total["clang-tidy"] = clang_tidy_comments
+            if clang_tidy_comments > 0:
+                self.tool_reused["clang-format"] = (
+                    self.tool_total["clang-format"] - clang_format_comments
+                )
+                self.tool_total["clang-format"] = clang_format_comments
 
 
 class PatchMixin(ABC):

--- a/cpp_linter/clang_tools/patcher.py
+++ b/cpp_linter/clang_tools/patcher.py
@@ -170,7 +170,7 @@ class ReviewComments:
                     self.tool_total["clang-tidy"] - clang_tidy_comments
                 )
                 self.tool_total["clang-tidy"] = clang_tidy_comments
-            if clang_tidy_comments > 0:
+            if clang_format_comments > 0:
                 self.tool_reused["clang-format"] = (
                     self.tool_total["clang-format"] - clang_format_comments
                 )

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -70,9 +70,9 @@ class Args(UserDict):
     #: See :std:option:`--passive-reviews`.
     passive_reviews: bool = False
     #: See :std:option:`--delete-review-comments`.
-    delete_comments: bool = False
+    delete_review_comments: bool = False
     #: See :std:option:`--reuse-review-comments`.
-    reuse_comments: bool = True
+    reuse_review_comments: bool = True
 
 
 _parser_args: Dict[Sequence[str], Any] = {}

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -362,19 +362,23 @@ _parser_args[("-R", "--passive-reviews")] = dict(
     help="""Set to ``true`` to prevent Pull Request
 reviews from requesting or approving changes.""",
 )
-_parser_args[("-C", "--delete-comments")] = dict(
+_parser_args[("-C", "--delete-review-comments")] = dict(
     default="true",
     type=lambda input: input.lower() == "true",
     help="""Set to ``true`` to delete existing outdated/unused
-review comments, ``false`` to just set them to resolved.
+Pull request review comments, ``false`` to just set them to resolved.
+This only effects review comments made when either
+:std:option:`--tidy-review` or :std:option:`--format-review` is enabled.
 
 Defaults to ``%(default)s``.""",
 )
-_parser_args[("-U", "--reuse-comments")] = dict(
+_parser_args[("-U", "--reuse-review-comments")] = dict(
     default="true",
     type=lambda input: input.lower() == "true",
-    help="""Set to ``true`` to reuse existing review
-comments if nothing has changed instead of making new ones.
+    help="""Set to ``true`` to reuse existing Pull request
+review comments if nothing has changed instead of making new ones.
+This only effects review comments made when either
+:std:option:`--tidy-review` or :std:option:`--format-review` is enabled.
 
 Defaults to ``%(default)s``.""",
 )

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -70,7 +70,7 @@ class Args(UserDict):
     #: See :std:option:`--passive-reviews`.
     passive_reviews: bool = False
     #: See :std:option:`--delete-review-comments`.
-    delete_comments: bool = True
+    delete_comments: bool = False
     #: See :std:option:`--reuse-review-comments`.
     reuse_comments: bool = True
 

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -69,6 +69,10 @@ class Args(UserDict):
     ignore_format: str = ""
     #: See :std:option:`--passive-reviews`.
     passive_reviews: bool = False
+    #: See :std:option:`--delete-comments`.
+    delete_comments: bool = True
+    #: See :std:option:`--reuse-comments`.
+    reuse_comments: bool = True
 
 
 _parser_args: Dict[Sequence[str], Any] = {}
@@ -357,6 +361,22 @@ _parser_args[("-R", "--passive-reviews")] = dict(
     type=lambda input: input.lower() == "true",
     help="""Set to ``true`` to prevent Pull Request
 reviews from requesting or approving changes.""",
+)
+_parser_args[("-C", "--delete-comments")] = dict(
+    default="true",
+    type=lambda input: input.lower() == "true",
+    help="""Set to ``true`` to delete existing outdated/unused
+review comments, ``false`` to just set them to resolved.
+
+Defaults to ``%(default)s``.""",
+)
+_parser_args[("-U", "--reuse-comments")] = dict(
+    default="true",
+    type=lambda input: input.lower() == "true",
+    help="""Set to ``true`` to reuse existing review
+comments if nothing has changed instead of making new ones.
+
+Defaults to ``%(default)s``.""",
 )
 
 

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -69,9 +69,9 @@ class Args(UserDict):
     ignore_format: str = ""
     #: See :std:option:`--passive-reviews`.
     passive_reviews: bool = False
-    #: See :std:option:`--delete-comments`.
+    #: See :std:option:`--delete-review-comments`.
     delete_comments: bool = True
-    #: See :std:option:`--reuse-comments`.
+    #: See :std:option:`--reuse-review-comments`.
     reuse_comments: bool = True
 
 
@@ -363,7 +363,7 @@ _parser_args[("-R", "--passive-reviews")] = dict(
 reviews from requesting or approving changes.""",
 )
 _parser_args[("-C", "--delete-review-comments")] = dict(
-    default="true",
+    default="false",
     type=lambda input: input.lower() == "true",
     help="""Set to ``true`` to delete existing outdated/unused
 Pull request review comments, ``false`` to just set them to resolved.

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -71,8 +71,6 @@ class Args(UserDict):
     passive_reviews: bool = False
     #: See :std:option:`--delete-review-comments`.
     delete_review_comments: bool = False
-    #: See :std:option:`--reuse-review-comments`.
-    reuse_review_comments: bool = True
 
 
 _parser_args: Dict[Sequence[str], Any] = {}
@@ -367,16 +365,6 @@ _parser_args[("-C", "--delete-review-comments")] = dict(
     type=lambda input: input.lower() == "true",
     help="""Set to ``true`` to delete existing outdated/unused
 Pull request review comments, ``false`` to just set them to resolved.
-This only effects review comments made when either
-:std:option:`--tidy-review` or :std:option:`--format-review` is enabled.
-
-Defaults to ``%(default)s``.""",
-)
-_parser_args[("-U", "--reuse-review-comments")] = dict(
-    default="true",
-    type=lambda input: input.lower() == "true",
-    help="""Set to ``true`` to reuse existing Pull request
-review comments if nothing has changed instead of making new ones.
 This only effects review comments made when either
 :std:option:`--tidy-review` or :std:option:`--format-review` is enabled.
 

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -365,7 +365,7 @@ _parser_args[("-C", "--delete-review-comments")] = dict(
     type=lambda input: input.lower() == "true",
     help="""Set to ``true`` to delete existing outdated/unused
 Pull request review comments, ``false`` to just set them to resolved.
-This only effects review comments made when either
+This only affects review comments made when either
 :std:option:`--tidy-review` or :std:option:`--format-review` is enabled.
 
 Defaults to ``%(default)s``.""",

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -620,7 +620,7 @@ class GithubApiClient(RestApiClient):
             self.pull_request,
         )
         response = self.api_request(
-            url="https://api.github.com/graphql",
+            url=f"{self.api_url}/graphql",
             method="POST",
             data=json.dumps(
                 {"query": query}

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -342,8 +342,8 @@ class GithubApiClient(RestApiClient):
                 no_lgtm=args.no_lgtm,
                 passive_reviews=args.passive_reviews,
                 clang_versions=clang_versions,
-                delete_comments=args.delete_comments,
-                reuse_comments=args.reuse_comments,
+                delete_review_comments=args.delete_review_comments,
+                reuse_review_comments=args.reuse_review_comments,
             )
 
     def make_annotations(
@@ -480,8 +480,8 @@ class GithubApiClient(RestApiClient):
         no_lgtm: bool,
         passive_reviews: bool,
         clang_versions: ClangVersions,
-        delete_comments: bool = True,
-        reuse_comments: bool = True,
+        delete_review_comments: bool = True,
+        reuse_review_comments: bool = True,
     ):
         url = f"{self.api_url}/repos/{self.repo}/pulls/{self.pull_request}"
         response = self.api_request(url=url)
@@ -516,10 +516,10 @@ class GithubApiClient(RestApiClient):
         ignored_reviews = []
         if not summary_only:
             found_threads = self._get_existing_review_comments(
-                no_dismissed=reuse_comments and not delete_comments
+                no_dismissed=reuse_review_comments and not delete_review_comments
             )
             if found_threads:
-                if reuse_comments:
+                if reuse_review_comments:
                     # Keep already posted comments if they match new ones
                     review_comments_suggestions = review_comments.suggestions
                     review_comments.suggestions = []
@@ -558,7 +558,7 @@ class GithubApiClient(RestApiClient):
                                     break
                             if not found:
                                 self._close_review_comment(
-                                    thread["id"], comment["id"], delete_comments
+                                    thread["id"], comment["id"], delete_review_comments
                                 )
                     for suggestion in review_comments_suggestions:
                         if suggestion not in existing_review_comments:
@@ -568,7 +568,7 @@ class GithubApiClient(RestApiClient):
                     for thread in found_threads:
                         for comment in thread["comments"]["nodes"]:
                             self._close_review_comment(
-                                thread["id"], comment["id"], delete_comments
+                                thread["id"], comment["id"], delete_review_comments
                             )
         self._hide_stale_reviews(ignored_reviews=ignored_reviews)
         if len(review_comments.suggestions) == 0 and len(ignored_reviews) > 0:

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -528,9 +528,8 @@ class GithubApiClient(RestApiClient):
                     for thread in found_threads:
                         for comment in thread["comments"]["nodes"]:
                             found = False
-                            assert (
-                                "originalLine" in comment
-                            ), "GraphQL response malformed"
+                            if "originalLine" not in comment:
+                                raise KeyError("GraphQL response malformed: 'originalLine' missing in comment")
                             line_start = comment.get("startLine", None) or comment.get("originalStartLine", None) or -1
                             line_end = comment.get("line", None) or comment["originalLine"]
                             for suggestion in review_comments_suggestions:
@@ -691,11 +690,7 @@ class GithubApiClient(RestApiClient):
                             and thread["isCollapsed"] is False
                         )
                     )
-                    and comment["author"]["login"] == "github-actions"
-                    and (
-                        comment["body"].strip().startswith("### clang-format")
-                        or comment["body"].strip().startswith("### clang-tidy")
-                    )
+                    and comment["body"].startswith(COMMENT_MARKER)
                 ):
                     found_threads.append(thread)
                     break

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -56,9 +56,6 @@ QUERY_REVIEW_COMMENTS = """
                             startLine
                             originalLine
                             originalStartLine
-                            author {
-                                login
-                            }
                             pullRequestReview {
                                 id
                                 isMinimized

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -463,12 +463,13 @@ class GithubApiClient(RestApiClient):
                     for thread in found_threads:
                         for comment in thread["comments"]["nodes"]:
                             found = False
-                            line_start = comment["originalStartLine"] if comment["originalStartLine"] is not None else -1
+                            line_start = comment.get("originalStartLine", -1)
                             line_end = comment["originalLine"]
                             if comment["startLine"] is not None:
-                                line_start = comment["startLine"] if comment["startLine"] is not None else (
-                                    comment["line"] if comment["line"] is not None else line_start)
-                                line_end = comment["line"] if comment["line"] is not None else line_end
+                                line_start = comment.get(
+                                    "startLine", comment.get("line", line_start)
+                                )
+                                line_end = comment.get("line", line_end)
                             for suggestion in review_comments_suggestions:
                                 if (suggestion.file_name == comment["path"] and suggestion.line_start == line_start and suggestion.line_end == line_end and suggestion.comment == comment["body"] and suggestion not in existing_review_comments and thread["isResolved"] is False and thread["isCollapsed"] is False):
                                     found = True

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -529,9 +529,17 @@ class GithubApiClient(RestApiClient):
                         for comment in thread["comments"]["nodes"]:
                             found = False
                             if "originalLine" not in comment:
-                                raise KeyError("GraphQL response malformed: 'originalLine' missing in comment")
-                            line_start = comment.get("startLine", None) or comment.get("originalStartLine", None) or -1
-                            line_end = comment.get("line", None) or comment["originalLine"]
+                                raise KeyError(
+                                    "GraphQL response malformed: 'originalLine' missing in comment"
+                                )
+                            line_start = (
+                                comment.get("startLine", None)
+                                or comment.get("originalStartLine", None)
+                                or -1
+                            )
+                            line_end = (
+                                comment.get("line", None) or comment["originalLine"]
+                            )
                             for suggestion in review_comments_suggestions:
                                 if (
                                     suggestion.file_name == comment["path"]
@@ -673,7 +681,8 @@ class GithubApiClient(RestApiClient):
         )
         if response.status_code != 200:
             logger.error(
-                "Could not get existing review thread comments: %d", response.status_code
+                "Could not get existing review thread comments: %d",
+                response.status_code,
             )
             return
         data = response.json()
@@ -717,7 +726,11 @@ class GithubApiClient(RestApiClient):
             strict=False,
         )
         if response.status_code != 200:
-            logger.error("Failed to %s review thread comment: %d", operation, response.status_code)
+            logger.error(
+                "Failed to %s review thread comment: %d",
+                operation,
+                response.status_code,
+            )
         elif "errors" in response.json():
             error_msg = response.json()["errors"][0]["message"]
             if "Resource not accessible by integration" in error_msg:
@@ -725,7 +738,9 @@ class GithubApiClient(RestApiClient):
                     "Changing review thread comments requires `contents: write` permission."
                 )
             else:
-                logger.error("Failed to %s review thread comment: %s", operation, error_msg)
+                logger.error(
+                    "Failed to %s review thread comment: %s", operation, error_msg
+                )
         else:
             logger.debug("Review comment thread %sd: %s", operation, thread_id)
 

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -70,7 +70,7 @@ query {
     }
 }
 """
-        
+
 RESOLVE_REVIEW_COMMENT = """
 mutation {
     resolveReviewThread(input: {threadId:"%s", clientMutationId:"github-actions"}) {
@@ -714,7 +714,7 @@ class GithubApiClient(RestApiClient):
         if delete:
             mutation = DELETE_REVIEW_COMMENT % (comment_id)
         response = self.api_request(
-            url="https://api.github.com/graphql",
+            url=f"{self.api_url}/graphql",
             method="POST",
             data=json.dumps({"query": mutation}),
             strict=False,
@@ -751,7 +751,7 @@ class GithubApiClient(RestApiClient):
                 ):
                     mutation = HIDE_REVIEW_COMMENT % (review["node_id"])
                     response = self.api_request(
-                        url="https://api.github.com/graphql",
+                        url=f"{self.api_url}/graphql",
                         method="POST",
                         data=json.dumps({"query": mutation}),
                         strict=False,

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -531,10 +531,8 @@ class GithubApiClient(RestApiClient):
                             assert (
                                 "originalLine" in comment
                             ), "GraphQL response malformed"
-                            line_end = comment.get("line", comment["originalLine"])
-                            line_start = comment.get(
-                                "startLine", comment.get("originalStartLine", -1)
-                            )
+                            line_start = comment.get("startLine", None) or comment.get("originalStartLine", None) or -1
+                            line_end = comment.get("line", None) or comment["originalLine"]
                             for suggestion in review_comments_suggestions:
                                 if (
                                     suggestion.file_name == comment["path"]

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -280,6 +280,8 @@ class GithubApiClient(RestApiClient):
                 no_lgtm=args.no_lgtm,
                 passive_reviews=args.passive_reviews,
                 clang_versions=clang_versions,
+                delete_comments=args.delete_comments,
+                reuse_comments=args.reuse_comments,
             )
 
     def make_annotations(

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -9,7 +9,6 @@ designed around GitHub's REST API.
     - `github rest API reference for issues <https://docs.github.com/en/rest/issues>`_
 """
 
-import copy
 import json
 import logging
 from os import environ
@@ -25,7 +24,7 @@ from ..clang_tools.clang_format import (
     tally_format_advice,
 )
 from ..clang_tools.clang_tidy import tally_tidy_advice
-from ..clang_tools.patcher import Suggestion, ReviewComments, PatchMixin
+from ..clang_tools.patcher import ReviewComments, PatchMixin
 from ..clang_tools import ClangVersions
 from ..cli import Args
 from ..loggers import logger, log_commander

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -101,6 +101,7 @@ mutation {
 }
 """
 
+
 class GithubApiClient(RestApiClient):
     """A class that describes the API used to interact with Github's REST API."""
 
@@ -527,13 +528,13 @@ class GithubApiClient(RestApiClient):
                     for thread in found_threads:
                         for comment in thread["comments"]["nodes"]:
                             found = False
-                            line_start = comment.get("originalStartLine", -1)
-                            line_end = comment["originalLine"]
-                            if comment["startLine"] is not None:
-                                line_start = comment.get(
-                                    "startLine", comment.get("line", line_start)
-                                )
-                                line_end = comment.get("line", line_end)
+                            assert (
+                                "originalLine" in comment
+                            ), "GraphQL response malformed"
+                            line_end = comment.get("line", comment["originalLine"])
+                            line_start = comment.get(
+                                "startLine", comment.get("originalStartLine", -1)
+                            )
                             for suggestion in review_comments_suggestions:
                                 if (
                                     suggestion.file_name == comment["path"]
@@ -680,7 +681,8 @@ class GithubApiClient(RestApiClient):
             return
         data = response.json()
         found_threads = []
-        for thread in data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]:
+        nodes = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        for thread in nodes:
             for comment in thread["comments"]["nodes"]:
                 if (
                     comment["id"]

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -570,7 +570,7 @@ class GithubApiClient(RestApiClient):
                 file_obj, summary_only, review_comments
             )
 
-    def _dismiss_stale_reviews(self, url: str, ignored_reviews: List[str] = []):
+    def _dismiss_stale_reviews(self, url: str, ignored_reviews: List[str] = None):
         """Dismiss all reviews that were previously created by cpp-linter"""
         next_page: Optional[str] = url + "?page=1&per_page=100"
         while next_page:
@@ -584,7 +584,10 @@ class GithubApiClient(RestApiClient):
                     and cast(str, review["body"]).startswith(COMMENT_MARKER)
                     and "state" in review
                     and review["state"] not in ["PENDING", "DISMISSED"]
-                    and review["node_id"] not in ignored_reviews
+                    and (
+                        ignored_reviews is not None
+                        and review["node_id"] not in ignored_reviews
+                    )
                 ):
                     assert "id" in review
                     self.api_request(

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -667,10 +667,11 @@ class GithubApiClient(RestApiClient):
             strict=False,
         )
         logger.debug(
-            "%s review comment thread %s (thread_id: %s)",
+            "%s review comment %s (%s: %s)",
             operation.title(),
             "failed" if response.status_code != 200 else "succeeded",
-            thread_id,
+            "comment_id" if delete else "thread_id",
+            comment_id if delete else thread_id,
         )
 
     def _hide_stale_reviews(self, ignored_reviews: List[str]):

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -570,9 +570,11 @@ class GithubApiClient(RestApiClient):
                 file_obj, summary_only, review_comments
             )
 
-    def _dismiss_stale_reviews(self, url: str, ignored_reviews: Optional[List[str]] = None):
+    def _dismiss_stale_reviews(
+        self, url: str, ignored_reviews: Optional[List[str]] = None
+    ):
         """Dismiss reviews that were previously created by cpp-linter.
-        
+
         Use ``ignored_reviews`` to only dismiss the reviews not specified in
         the given list. If ``ignored_reviews`` is `None`, then dismiss all
         reviews.
@@ -633,7 +635,11 @@ class GithubApiClient(RestApiClient):
             return
         data = response.json()
         found_threads = []
-        nodes = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        try:
+            nodes = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        except KeyError as exc:  # pragma: no cover
+            logger.error("Malformed GraphQL response: Field %s not found", exc.args[0])
+            return
         for thread in nodes:
             for comment in thread["comments"]["nodes"]:
                 if (

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -570,8 +570,13 @@ class GithubApiClient(RestApiClient):
                 file_obj, summary_only, review_comments
             )
 
-    def _dismiss_stale_reviews(self, url: str, ignored_reviews: List[str] = None):
-        """Dismiss all reviews that were previously created by cpp-linter"""
+    def _dismiss_stale_reviews(self, url: str, ignored_reviews: Optional[List[str]] = None):
+        """Dismiss reviews that were previously created by cpp-linter.
+        
+        Use ``ignored_reviews`` to only dismiss the reviews not specified in
+        the given list. If ``ignored_reviews`` is `None`, then dismiss all
+        reviews.
+        """
         next_page: Optional[str] = url + "?page=1&per_page=100"
         while next_page:
             response = self.api_request(url=next_page)
@@ -585,8 +590,11 @@ class GithubApiClient(RestApiClient):
                     and "state" in review
                     and review["state"] not in ["PENDING", "DISMISSED"]
                     and (
-                        ignored_reviews is not None
-                        and review["node_id"] not in ignored_reviews
+                        ignored_reviews is None
+                        or (
+                            "node_id" in review
+                            and review["node_id"] not in ignored_reviews
+                        )
                     )
                 ):
                     assert "id" in review

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -628,7 +628,7 @@ class GithubApiClient(RestApiClient):
                 file_obj, summary_only, review_comments
             )
 
-    def _dismiss_stale_reviews(self, url: str, ignored_reviews: List[str]):
+    def _dismiss_stale_reviews(self, url: str, ignored_reviews: List[str] = []):
         """Dismiss all reviews that were previously created by cpp-linter"""
         next_page: Optional[str] = url + "?page=1&per_page=100"
         while next_page:

--- a/tests/reviews/pr_reviews_graphql.json
+++ b/tests/reviews/pr_reviews_graphql.json
@@ -1,0 +1,115 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "id": "PR_kwDOFY2uzM5jZGgl",
+        "reviewThreads": {
+          "nodes": [
+            {
+              "id": "PRRT_kwDOFY2uzM42_-w5",
+              "isResolved": false,
+              "isCollapsed": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "PRRC_kwDOFY2uzM5WD6gj",
+                    "body": "### clang-format suggestions\n\n```suggestion\n\r\nint main()\r\n{\r\n\r\n    for (;;)\r\n        break;\r\n\r\n```",
+                    "path": "src/demo.cpp",
+                    "line": 13,
+                    "startLine": 4,
+                    "originalLine": 13,
+                    "originalStartLine": 4,
+                    "author": {
+                      "login": "github-actions"
+                    },
+                    "pullRequestReview": {
+                      "id": "PRR_kwDOFY2uzM5rveb6"
+                    }
+                  },
+                  {
+                    "id": "PRRC_kwDOFY2uzM5WEqkw",
+                    "body": "The `printf()`seems to be getting dropped in this suggestion.",
+                    "path": "src/demo.cpp",
+                    "line": 13,
+                    "startLine": 4,
+                    "originalLine": 13,
+                    "originalStartLine": 4,
+                    "author": {
+                      "login": "2bndy5"
+                    },
+                    "pullRequestReview": {
+                      "id": "PRR_kwDOFY2uzM5rwcy4"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "PRRT_kwDOFY2uzM42_-w6",
+              "isResolved": false,
+              "isCollapsed": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "PRRC_kwDOFY2uzM5WD6gk",
+                    "body": "### clang-tidy diagnostics\n- inclusion of deprecated C++ header 'stdio.h'; consider using 'cstdio' instead [[modernize-deprecated-headers](https://clang.llvm.org/extra/clang-tidy/checks/modernize/deprecated-headers.html)]\n- use a trailing return type for this function [[modernize-use-trailing-return-type](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-trailing-return-type.html)]\n- statement should be inside braces [[readability-braces-around-statements](https://clang.llvm.org/extra/clang-tidy/checks/readability/braces-around-statements.html)]\n\n```suggestion\n#include \"demo.hpp\"\r\n#include <cstdio>\r\n\r\nauto main() -> int\r\n{\r\n\r\n    for (;;) {\r\n        break;\r\n    }\r\n\r\n```",
+                    "path": "src/demo.cpp",
+                    "line": 13,
+                    "startLine": 2,
+                    "originalLine": 13,
+                    "originalStartLine": 2,
+                    "author": {
+                      "login": "github-actions"
+                    },
+                    "pullRequestReview": {
+                      "id": "PRR_kwDOFY2uzM5rveb6"
+                    }
+                  },
+                  {
+                    "id": "PRRC_kwDOFY2uzM5WEqlw",
+                    "body": "Again, the `printf()` call is getting dropped in this suggestion.",
+                    "path": "src/demo.cpp",
+                    "line": 13,
+                    "startLine": 2,
+                    "originalLine": 13,
+                    "originalStartLine": 2,
+                    "author": {
+                      "login": "2bndy5"
+                    },
+                    "pullRequestReview": {
+                      "id": "PRR_kwDOFY2uzM5rwc0g"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "PRRT_kwDOFY2uzM42_-w7",
+              "isResolved": false,
+              "isCollapsed": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "PRRC_kwDOFY2uzM5WD6gm",
+                    "body": "### clang-tidy diagnostics\n- use a trailing return type for this function [[modernize-use-trailing-return-type](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-trailing-return-type.html)]\n\n```suggestion\n    public:\r\n        auto not_useful(char* str) -> void* { useless = str; }\r\n};\r\n```",
+                    "path": "src/demo.hpp",
+                    "line": 13,
+                    "startLine": 10,
+                    "originalLine": 13,
+                    "originalStartLine": 10,
+                    "author": {
+                      "login": "github-actions"
+                    },
+                    "pullRequestReview": {
+                      "id": "PRR_kwDOFY2uzM5rveb6"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/reviews/test_pr_review.py
+++ b/tests/reviews/test_pr_review.py
@@ -145,12 +145,13 @@ def test_post_review(
 
         def graphql_callback(request, context):
             context.status_code = 200
-            if request.data.startswith("query"):
+            query: str = request.json()["query"]
+            if query.startswith("query"):
                 # get existing review comments
                 return (cache_path / "pr_reviews_graphql.json").read_text(
                     encoding="utf-8"
                 )
-            elif "resolveReviewThread" in request.data:
+            elif "resolveReviewThread" in query:
                 # resolve review
                 id_pos = request.data.find('threadId:"') + 10
                 id_end_pos = request.data.find('"', id_pos + 1)
@@ -167,7 +168,7 @@ def test_post_review(
 }"""
                     % id_tag
                 )
-            elif "deletePullRequestReviewComment" in request.data:
+            elif "deletePullRequestReviewComment" in query:
                 # delete PR or minimizeComment
                 id_pos = request.data.find('id:"') + 4
                 id_end_pos = request.data.find('"', id_pos + 1)
@@ -184,7 +185,7 @@ def test_post_review(
 }"""
                     % id_tag
                 )
-            elif "minimizeComment" in request.data:
+            elif "minimizeComment" in query:
                 # minimizeComment
                 return """{
   "data": {
@@ -195,7 +196,13 @@ def test_post_review(
     }
   }
 }"""
-            return "errors"
+            return json.dumps(
+                {
+                    "errors": [
+                        {"message": "Failed to parse query when mocking a response"}
+                    ]
+                }
+            )
 
         mock.post(graphql_url, text=graphql_callback)
 

--- a/tests/reviews/test_pr_review.py
+++ b/tests/reviews/test_pr_review.py
@@ -154,7 +154,7 @@ def test_post_review(
                 # resolve review
                 id_pos = request.data.find('threadId:"') + 10
                 id_end_pos = request.data.find('"', id_pos + 1)
-                id = request.data[id_pos, id_end_pos]
+                id_tag = request.data[id_pos, id_end_pos]
                 return (
                     """{
   "data": {
@@ -165,13 +165,13 @@ def test_post_review(
     }
   }
 }"""
-                    % id
+                    % id_tag
                 )
             elif request.data.find("deletePullRequestReviewComment") is not -1:
                 # delete PR or minimizeComment
                 id_pos = request.data.find('id:"') + 4
                 id_end_pos = request.data.find('"', id_pos + 1)
-                id = request.data[id_pos, id_end_pos]
+                id_tag = request.data[id_pos, id_end_pos]
                 return (
                     """{
   "data": {
@@ -182,7 +182,7 @@ def test_post_review(
     }
   }
 }"""
-                    % id
+                    % id_tag
                 )
             elif request.data.find("minimizeComment") is not -1:
                 # minimizeComment

--- a/tests/reviews/test_pr_review.py
+++ b/tests/reviews/test_pr_review.py
@@ -145,12 +145,12 @@ def test_post_review(
 
         def graphql_callback(request, context):
             context.status_code = 200
-            if request.data.find("query") is not -1:
+            if request.data.startswith("query"):
                 # get existing review comments
                 return (cache_path / "pr_reviews_graphql.json").read_text(
                     encoding="utf-8"
                 )
-            elif request.data.find("resolveReviewThread") is not -1:
+            elif "resolveReviewThread" in request.data:
                 # resolve review
                 id_pos = request.data.find('threadId:"') + 10
                 id_end_pos = request.data.find('"', id_pos + 1)
@@ -167,7 +167,7 @@ def test_post_review(
 }"""
                     % id_tag
                 )
-            elif request.data.find("deletePullRequestReviewComment") is not -1:
+            elif "deletePullRequestReviewComment" in request.data:
                 # delete PR or minimizeComment
                 id_pos = request.data.find('id:"') + 4
                 id_end_pos = request.data.find('"', id_pos + 1)
@@ -184,7 +184,7 @@ def test_post_review(
 }"""
                     % id_tag
                 )
-            elif request.data.find("minimizeComment") is not -1:
+            elif "minimizeComment" in request.data:
                 # minimizeComment
                 return """{
   "data": {

--- a/tests/reviews/test_pr_review.py
+++ b/tests/reviews/test_pr_review.py
@@ -154,7 +154,7 @@ def test_post_review(
                 # resolve review
                 id_pos = request.data.find('threadId:"') + 10
                 id_end_pos = request.data.find('"', id_pos + 1)
-                id_tag = request.data[id_pos, id_end_pos]
+                id_tag = request.data[id_pos:id_end_pos]
                 return (
                     """{
   "data": {
@@ -171,7 +171,7 @@ def test_post_review(
                 # delete PR or minimizeComment
                 id_pos = request.data.find('id:"') + 4
                 id_end_pos = request.data.find('"', id_pos + 1)
-                id_tag = request.data[id_pos, id_end_pos]
+                id_tag = request.data[id_pos:id_end_pos]
                 return (
                     """{
   "data": {


### PR DESCRIPTION
This extends the existing cang-tidy/format review capability by adding additional functionality:

- Auto hide/minimize old outdated review comments
- Mark outdated review conversations as resolved
- Delete outdated review conversations (user option to select between resolving or deleting)
- Reuse existing review conversations on subsequent runs in case issue is still present (prevent spam comments for identical issues being continuously added on each run)(user option to either resue or resolve/delete and repost)
- Reuse existing review comment on subsequent runs for issues still present while also creating a new comment should any additional new issues be detected (reduces duplicate issue spam)

Uses graphql queries to provide additional functionality beyond what the github api suppots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced options to manage pull request review comments: delete outdated comments and reuse existing comments.
  - Enhanced GitHub API client with new GraphQL queries and mutations for improved review comment management.
  - Added functionality to track and report reused suggestions in review summaries.

- **Bug Fixes**
  - Improved handling of existing review comments, including fetching, closing, and hiding stale reviews.

- **Tests**
  - Added mock GraphQL request handling in tests to simulate interactions with the GitHub API for review comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->