### PR TITLE
prefix every review comment

### DIFF
--- a/cpp_linter/clang_tools/patcher.py
+++ b/cpp_linter/clang_tools/patcher.py
@@ -37,7 +37,13 @@ class Suggestion:
     def serialize_to_github_payload(self) -> Dict[str, Any]:
         """Serialize this object into a JSON compatible with Github's REST API."""
         assert self.line_end > 0, "ending line number unknown"
-        result = {"path": self.file_name, "body": self.comment, "line": self.line_end}
+        from ..rest_api import COMMENT_MARKER  # workaround circular import
+
+        result = {
+            "path": self.file_name,
+            "body": f"{COMMENT_MARKER}{self.comment}",
+            "line": self.line_end,
+        }
         if self.line_start != self.line_end and self.line_start > 0:
             result["start_line"] = self.line_start
         return result


### PR DESCRIPTION
With the html marker used in our other generated comments. This is to avoid ambiguity and help on-board new features in #131.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the serialization of comments to include a comment marker, enhancing the clarity of serialized outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->