### PR TITLE
add: File IO timeout API

### DIFF
--- a/cpp_linter/clang_tools/__init__.py
+++ b/cpp_linter/clang_tools/__init__.py
@@ -6,7 +6,7 @@ import subprocess
 from typing import Optional, List, Dict, Tuple, cast
 import shutil
 
-from ..common_fs import FileObj
+from ..common_fs import FileObj, FileIOTimeout
 from ..common_fs.file_filter import TidyFileFilter, FormatFileFilter
 from ..loggers import start_log_group, end_log_group, worker_log_init, logger
 from .clang_tidy import run_clang_tidy, TidyAdvice
@@ -45,34 +45,52 @@ def _run_on_single_file(
     args: Args,
 ) -> Tuple[str, str, Optional[TidyAdvice], Optional[FormatAdvice]]:
     log_stream = worker_log_init(log_lvl)
+    filename = Path(file.name).as_posix()
 
     format_advice = None
     if format_cmd is not None and (
         format_filter is None or format_filter.is_source_or_ignored(file.name)
     ):
-        format_advice = run_clang_format(
-            command=format_cmd,
-            file_obj=file,
-            style=args.style,
-            lines_changed_only=args.lines_changed_only,
-            format_review=args.format_review,
-        )
+        try:
+            format_advice = run_clang_format(
+                command=format_cmd,
+                file_obj=file,
+                style=args.style,
+                lines_changed_only=args.lines_changed_only,
+                format_review=args.format_review,
+            )
+        except FileIOTimeout:  # pragma: no cover
+            logger.error(
+                "Failed to read or write contents of %s when running clang-format",
+                filename,
+            )
+        except OSError:  # pragma: no cover
+            logger.error(
+                "Failed to open the file %s when running clang-format", filename
+            )
 
     tidy_note = None
     if tidy_cmd is not None and (
         tidy_filter is None or tidy_filter.is_source_or_ignored(file.name)
     ):
-        tidy_note = run_clang_tidy(
-            command=tidy_cmd,
-            file_obj=file,
-            checks=args.tidy_checks,
-            lines_changed_only=args.lines_changed_only,
-            database=args.database,
-            extra_args=args.extra_arg,
-            db_json=db_json,
-            tidy_review=args.tidy_review,
-            style=args.style,
-        )
+        try:
+            tidy_note = run_clang_tidy(
+                command=tidy_cmd,
+                file_obj=file,
+                checks=args.tidy_checks,
+                lines_changed_only=args.lines_changed_only,
+                database=args.database,
+                extra_args=args.extra_arg,
+                db_json=db_json,
+                tidy_review=args.tidy_review,
+                style=args.style,
+            )
+        except FileIOTimeout:  # pragma: no cover
+            logger.error(
+                "Failed to Read/Write contents of %s when running clang-tidy", filename
+            )
+        except OSError:  # pragma: no cover
+            logger.error("Failed to open the file %s when running clang-tidy", filename)
 
     return file.name, log_stream.getvalue(), tidy_note, format_advice
 

--- a/cpp_linter/clang_tools/__init__.py
+++ b/cpp_linter/clang_tools/__init__.py
@@ -46,6 +46,18 @@ def _run_on_single_file(
 ) -> Tuple[str, str, Optional[TidyAdvice], Optional[FormatAdvice]]:
     log_stream = worker_log_init(log_lvl)
 
+    format_advice = None
+    if format_cmd is not None and (
+        format_filter is None or format_filter.is_source_or_ignored(file.name)
+    ):
+        format_advice = run_clang_format(
+            command=format_cmd,
+            file_obj=file,
+            style=args.style,
+            lines_changed_only=args.lines_changed_only,
+            format_review=args.format_review,
+        )
+
     tidy_note = None
     if tidy_cmd is not None and (
         tidy_filter is None or tidy_filter.is_source_or_ignored(file.name)
@@ -60,18 +72,6 @@ def _run_on_single_file(
             db_json=db_json,
             tidy_review=args.tidy_review,
             style=args.style,
-        )
-
-    format_advice = None
-    if format_cmd is not None and (
-        format_filter is None or format_filter.is_source_or_ignored(file.name)
-    ):
-        format_advice = run_clang_format(
-            command=format_cmd,
-            file_obj=file,
-            style=args.style,
-            lines_changed_only=args.lines_changed_only,
-            format_review=args.format_review,
         )
 
     return file.name, log_stream.getvalue(), tidy_note, format_advice

--- a/cpp_linter/clang_tools/clang_format.py
+++ b/cpp_linter/clang_tools/clang_format.py
@@ -130,12 +130,13 @@ def parse_format_replacements_xml(
         file_obj.range_of_changed_lines(lines_changed_only, get_ranges=True),
     )
     tree = ET.fromstring(xml_out)
+    content = file_obj.read_with_timeout()
     for child in tree:
         if child.tag == "replacement":
             null_len = int(child.attrib["length"])
             text = "" if child.text is None else child.text
             offset = int(child.attrib["offset"])
-            line, cols = get_line_cnt_from_cols(file_obj.name, offset)
+            line, cols = get_line_cnt_from_cols(content, offset)
             is_line_in_ranges = False
             for r in ranges:
                 if line in range(r[0], r[1]):  # range is inclusive

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -246,7 +246,7 @@ def run_clang_tidy(
     if tidy_review:
         # clang-tidy overwrites the file contents when applying fixes.
         # create a cache of original contents
-        original_buf = Path(file_obj.name).read_bytes()
+        original_buf = file_obj.read_with_timeout()
         cmds.append("--fix-errors")  # include compiler-suggested fixes
     cmds.append(filename)
     logger.info('Running "%s"', " ".join(cmds))
@@ -260,10 +260,8 @@ def run_clang_tidy(
     advice = parse_tidy_output(results.stdout.decode(), database=db_json)
 
     if tidy_review:
-        # store the modified output from clang-tidy
-        advice.patched = Path(file_obj.name).read_bytes()
-        # re-write original file contents
-        Path(file_obj.name).write_bytes(original_buf)
+        # store the modified output from clang-tidy and re-write original file contents
+        advice.patched = file_obj.read_write_with_timeout(original_buf)
 
     return advice
 

--- a/cpp_linter/clang_tools/patcher.py
+++ b/cpp_linter/clang_tools/patcher.py
@@ -2,7 +2,6 @@
 by the clang tool's output."""
 
 from abc import ABC
-from pathlib import Path
 from typing import Optional, Dict, Any, List, Tuple
 from pygit2 import Patch  # type: ignore
 from ..common_fs import FileObj
@@ -178,7 +177,7 @@ class PatchMixin(ABC):
             self.patched
         ), f"{self.__class__.__name__} has no suggestions for {file_obj.name}"
         patch = Patch.create_from(
-            Path(file_obj.name).read_bytes(),
+            file_obj.read_with_timeout(),
             self.patched,
             file_obj.name,
             file_obj.name,

--- a/cpp_linter/common_fs/__init__.py
+++ b/cpp_linter/common_fs/__init__.py
@@ -184,6 +184,8 @@ class FileObj:
                         if f.readable():
                             contents = f.read()
                             success = True
+                        else:  # pragma: no cover
+                            time.sleep(0.001)
             except OSError as exc:  # pragma: no cover
                 exception = exc
         if not success and exception:  # pragma: no cover
@@ -222,11 +224,15 @@ class FileObj:
                             original_data = f.read()
                             f.seek(0)
                         else:  # pragma: no cover
+                            time.sleep(0.001)
                             continue
                         while not success and time.monotonic_ns() < timeout:
                             if f.writable():
                                 f.write(data)
+                                f.truncate()
                                 success = True
+                            else:  # pragma: no cover
+                                time.sleep(0.001)
             except OSError as exc:  # pragma: no cover
                 exception = exc
         if not success and exception:  # pragma: no cover

--- a/cpp_linter/common_fs/__init__.py
+++ b/cpp_linter/common_fs/__init__.py
@@ -243,8 +243,6 @@ class FileObj:
 class FileIOTimeout(Exception):
     """An exception thrown when a file operation timed out."""
 
-    pass
-
 
 def has_line_changes(
     lines_changed_only: int, diff_chunks: List[List[int]], additions: List[int]

--- a/cpp_linter/common_fs/__init__.py
+++ b/cpp_linter/common_fs/__init__.py
@@ -173,8 +173,8 @@ class FileObj:
         contents = b""
         success = False
         exception: Union[OSError, FileIOTimeout] = FileIOTimeout(
-            "Failed to read from file within %d seconds"
-            % round(timeout_ns / 1_000_000_000, 2)
+            f"Failed to read from file '{self.name}' within "
+            + f"{round(timeout_ns / 1_000_000_000, 2)} seconds"
         )
         timeout = time.monotonic_ns() + timeout_ns
         while not success and time.monotonic_ns() < timeout:
@@ -185,7 +185,7 @@ class FileObj:
                             contents = f.read()
                             success = True
                         else:  # pragma: no cover
-                            time.sleep(0.001)
+                            time.sleep(0.001)  # Sleep to prevent busy-waiting
             except OSError as exc:  # pragma: no cover
                 exception = exc
         if not success and exception:  # pragma: no cover
@@ -211,8 +211,8 @@ class FileObj:
         """
         success = False
         exception: Union[OSError, FileIOTimeout] = FileIOTimeout(
-            "Failed to read then write to file within %d seconds"
-            % round(timeout_ns / 1_000_000_000, 2)
+            f"Failed to read then write file '{self.name}' within "
+            + f"{round(timeout_ns / 1_000_000_000, 2)} seconds"
         )
         original_data = b""
         timeout = time.monotonic_ns() + timeout_ns
@@ -224,7 +224,7 @@ class FileObj:
                             original_data = f.read()
                             f.seek(0)
                         else:  # pragma: no cover
-                            time.sleep(0.001)
+                            time.sleep(0.001)  # Sleep to prevent busy-waiting
                             continue
                         while not success and time.monotonic_ns() < timeout:
                             if f.writable():
@@ -232,7 +232,7 @@ class FileObj:
                                 f.truncate()
                                 success = True
                             else:  # pragma: no cover
-                                time.sleep(0.001)
+                                time.sleep(0.001)  # Sleep to prevent busy-waiting
             except OSError as exc:  # pragma: no cover
                 exception = exc
         if not success and exception:  # pragma: no cover
@@ -268,7 +268,7 @@ def has_line_changes(
 def get_line_cnt_from_cols(data: bytes, offset: int) -> Tuple[int, int]:
     """Gets a line count and columns offset from a file's absolute offset.
 
-    :param data: Path to file.
+    :param data: Bytes content to analyze.
     :param offset: The byte offset to translate
 
     :returns:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -84,8 +84,8 @@ def test_list_src_files(
 @pytest.mark.parametrize("line,cols,offset", [(13, 5, 144), (19, 1, 189)])
 def test_file_offset_translation(line: int, cols: int, offset: int):
     """Validate output from ``get_line_cnt_from_cols()``"""
-    test_file = str(Path("tests/demo/demo.cpp").resolve())
-    assert (line, cols) == get_line_cnt_from_cols(test_file, offset)
+    contents = Path("tests/demo/demo.cpp").read_bytes()
+    assert (line, cols) == get_line_cnt_from_cols(contents, offset)
 
 
 def test_serialize_file_obj():


### PR DESCRIPTION
Born from the discussion in #129 and continued in #130. This adds timeout-oriented functions for reading and writing to the scanned source files.

This supersedes #130 and resolves #129.

Also while parsing clang-format's XML output, I'm now caching the bytes from a given scanned source file, so the line and column numbers are calculated on the cached bytes instead of re-reading the same source file repeatedly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new methods for file reading and writing with timeout capabilities.
	- Added a new exception class for file operation timeouts.

- **Bug Fixes**
	- Enhanced file handling in various components to improve reading efficiency and error management.
	- Improved error handling during formatting and tidying operations.

- **Tests**
	- Updated test implementation to align with new file reading methods, ensuring compatibility with byte data input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->