### PR TITLE
chore: follow up to #151

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,11 @@ updates:
       actions:
         patterns:
           - "*"
-  - package-ecosystem: uv
-    directory: /
-    schedule:
-      interval: "monthly"
-    groups:
-      uv-pip:
-        patterns:
-          - "*"
+  # - package-ecosystem: uv
+  #   directory: /
+  #   schedule:
+  #     interval: "monthly"
+  #   groups:
+  #     uv-pip:
+  #       patterns:
+  #         - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,13 +1,15 @@
 name: PR Autolabeler
 
 on:
-  # pull_request event is required for autolabeler
   pull_request:
     types: [opened, reopened, synchronize]
 
 jobs:
-  draft-release:
+  # Auto label PRs during a PR event
+  auto-label:
+    runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
-    uses: cpp-linter/.github/.github/workflows/release-drafter.yml@main
+    steps:
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,11 @@ on:
 permissions: {}
 
 jobs:
+  # Draft your next Release notes as Pull Requests are merged into the default branch
   draft-release:
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-    uses: cpp-linter/.github/.github/workflows/release-drafter.yml@main
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0


### PR DESCRIPTION
Some permissions were in adequate after merging #151. This was hard to predict because the permission requirements changed between PR and push events to main.

See also cpp-linter/.github#47

## Disable dependabot for `uv`

I disabled dependabot for uv because it is somehow broken. There are a [number of issues about it in dependabot-core repo](https://github.com/dependabot/dependabot-core/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22L%3A%20python%3Auv%22), but no progress seems to be made.

I'm not sure what to do in the meantime. Maybe I'll just bump uv deps locally and push chasnges. Or I could create a scheduled workflow to do the dependabot behavior manually. I recently had to do this [for `deno` in a different project](https://github.com/2bndy5/redist-icons/actions/runs/17450146322).
