### PR TITLE
chore: switch back to reusable docs CI workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,8 @@ name: Build Docs
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions: {}
@@ -10,49 +12,10 @@ env:
   PATH_TO_DOCS: docs/_build/html
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6 # v6.6.1
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Build docs
-        run: uvx nox -s docs
-
-      - name: Upload docs build as artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ github.event.repository.name }}_docs
-          path: ${{ env.PATH_TO_DOCS }}
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: [build]
-    # only publish doc changes from main branch
-    if: github.ref == 'refs/heads/main' && github.repository == 'cpp-linter/cpp-linter'
+  docs:
     permissions:
-      # needed to publish docs to the gh-pages branch
-      contents: write
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-
-      - name: Download built docs artifact
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          name: ${{ github.event.repository.name }}_docs
-          path: ${{ env.PATH_TO_DOCS }}
-
-      - name: Upload to github pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.PATH_TO_DOCS }}
+      # to deploy to Pages
+      pages: write
+      # to verify the deployment originates from an appropriate source
+      id-token: write
+    uses: cpp-linter/.github/.github/workflows/sphinx.yml@main

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,4 +10,6 @@ permissions: {}
 
 jobs:
   pre-commit:
+    permissions:
+      contents: read
     uses: cpp-linter/.github/.github/workflows/pre-commit.yml@main


### PR DESCRIPTION
now that it uses `uv` in reusable workflow

see also cpp-linter/.github#52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled documentation workflow to run on pull requests targeting main.
  * Consolidated docs build and deploy into a single job that invokes a reusable workflow.
  * Removed separate build and deploy steps to simplify CI.
  * Set explicit job permissions to allow GitHub Pages deployment and OIDC authentication.
  * Preserved docs path configuration while delegating build/deploy logic externally.
  * Scoped pre-commit job token to read repository contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->