### PR TITLE
fix: parse clang-tidy output when `WarningsAsErrors` is asserted

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,6 @@
 *.yml text eol=lf
 *.yaml text eol=lf
 *.toml text eol=lf
+*.lock text eol=lf
+.gitignore text eol=lf
+.gitattributes text eol=lf

--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -10,7 +10,9 @@ from ..loggers import logger
 from ..common_fs import FileObj
 from .patcher import PatchMixin, ReviewComments, Suggestion
 
-NOTE_HEADER = re.compile(r"^(.+):(\d+):(\d+):\s(\w+):(.*)\[([a-zA-Z\d\-\.]+)\]$")
+NOTE_HEADER = re.compile(
+    r"^(.+):(\d+):(\d+):\s(\w+):(.*)\[([a-zA-Z\d\-\.]+),?[^\]]*\]$"
+)
 FIXED_NOTE = re.compile(r"^.+:(\d+):\d+:\snote: FIX-IT applied suggested code changes$")
 
 

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -455,7 +455,7 @@ def test_parse_diff(
             encoding="utf-8"
         )
         diff = diff.parse_diff(patch_to_stage)
-        repo.apply(diff, pygit2.GIT_APPLY_LOCATION_BOTH)
+        repo.apply(diff, pygit2.GIT_APPLY_LOCATION_BOTH)  # type: ignore[arg-type]
         repo.index.add_all(["tests/demo/demo.*"])
         repo.index.write()
     del repo

--- a/tests/demo/.clang-tidy
+++ b/tests/demo/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,bugprone-*,clang-analyzer-*,mpi-*,misc-*,readability-*'
-WarningsAsErrors: ''
+WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 FormatStyle:     'file'
 CheckOptions:


### PR DESCRIPTION
ref cpp-linter/cpp-linter-action#347

Basically, we just needed to account for the `,-warnings-as-errors` appended to the rule name in square brackets.

### Without `WarningsAsErrors`
```text
tests/demo/demo.cpp:2:1: error: included header demo.hpp is not used directly [misc-include-cleaner]
```
### With `WarningsAsErrors`
```text
tests/demo/demo.cpp:2:1: error: included header demo.hpp is not used directly [misc-include-cleaner,-warnings-as-errors]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved clang-tidy note parsing to recognize a wider range of note formats, reducing missed diagnostics.
* Chores
  * Enforced LF line endings for lock files and Git metadata via .gitattributes to ensure consistent text normalization across platforms.
* Tests
  * Enabled all Clang-Tidy warnings as errors in the demo configuration to tighten quality gates.
  * Added a type-check suppression in a test to stabilize typing without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->