### PR TITLE
chore: update pre-commit.ci commit_msg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
-  autofix_commit_msg: 'chore(dev): auto fixes from pre-commit.com hooks'
-  autoupdate_commit_msg: 'chore(dev): pre-commit autoupdate'
+  autofix_commit_msg: 'chore(dev): auto fixes from pre-commit.ci hooks'
+  autoupdate_commit_msg: 'chore(dev): pre-commit hooks autoupdate'
   autoupdate_schedule: quarterly
 
 repos:


### PR DESCRIPTION
Ref #165: Update pre-commit.ci commit message to pass Conventional Commits rules based on the 

https://pre-commit.ci/#configuration