### PR TITLE
fix: avoid appending `--extra-arg=` for clang-tidy

### DIFF
--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -248,7 +248,8 @@ def run_clang_tidy(
         extra_args = extra_args[0].split()
     for extra_arg in extra_args:
         arg = extra_arg.strip('"')
-        cmds.append(f"--extra-arg={arg}")
+        if arg:  # avoid adding empty arg values
+            cmds.append(f"--extra-arg={arg}")
     if tidy_review:
         # clang-tidy overwrites the file contents when applying fixes.
         # create a cache of original contents


### PR DESCRIPTION
This avoids adding a `--extra-arg=` (with no arg value) to clang-tidy invocations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug where empty argument values could be inadvertently passed to clang-tidy during execution. The argument construction logic now properly validates and filters out empty values before passing them to the tool, resulting in more reliable linting operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->