### PR TITLE
fix: use diagnostic name as default

### DIFF
--- a/cpp_linter/clang_tools/clang_tidy.py
+++ b/cpp_linter/clang_tools/clang_tidy.py
@@ -93,7 +93,7 @@ class TidyNotification:
             assert len(check_name_parts) > 2, "diagnostic name malformed"
             return link + "clang-analyzer/{}.html)".format(check_name_parts[2])
         diag_split = self.diagnostic.split("-", maxsplit=1)
-        if len(diag_split) < 2:
+        if len(diag_split) < 2 or not all(diag_split):
             return self.diagnostic
         return link + "{}/{}.html)".format(*diag_split)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -165,7 +165,7 @@ def test_diagnostic_link_no_hyphen() -> None:
             1,
             "error",
             "Test rationale",
-            "no diagnostic name",
+            "no_diagnostic_name",
         )
     )
-    assert note.diagnostic_link == "no diagnostic name"
+    assert note.diagnostic_link == "no_diagnostic_name"


### PR DESCRIPTION
This fixes a problem about hyperlinking a clang-tidy diagnostic name to the clang-tidy docs.

Specifically when the diagnostic name does not satisfy any of the following conditions:
- starts with `clang-diagnostic-`
- starts with `clang-analyzer-`
- contains at least 1 hyphen (`-`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic link handling to gracefully process diagnostics with unexpected formats. When a diagnostic identifier doesn't match the expected structure, the system now returns the raw diagnostic name instead of failing, enhancing overall reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->