### PR TITLE
perf: small optimizations to `get_diff()`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 *.py text eol=lf
 *.rst text eol=lf
 *.sh text eol=lf
+*.json text eol=lf
 *.cpp text eol=lf
 *.hpp text eol=lf
 *.yml text eol=lf

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import time
 from typing import cast
 from importlib.metadata import version as get_version
-import docutils
+import docutils  # type: ignore[import-untyped]
 from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxRole
 from sphinx_immaterial.inline_icons import load_svg_into_builder_env

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -188,6 +188,7 @@ def prep_tmp_dir(
     ],
     ids=["none", "HEAD", 2],
 )
+@pytest.mark.no_clang
 def test_get_sha(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
In porting #180 to rust (cpp-linter/cpp-linter-rs#260), I found a few spots for improvement.
These changes should be more performant when there are staged changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Normalized JSON line endings across the repo.
  * Suppressed a doc import type-check warning.

* **Bug Fixes**
  * Improved detection and handling of staged changes and diff computation for more accurate change reporting.

* **Tests**
  * Marked a test to run without clang-related tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->