### PR TITLE
build: drop python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "Brendan Doherty", email = "2bndy5@gmail.com" },
     { name = "Xianpeng Shen", email = "xianpeng.shen@gmail.com" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     # https://pypi.org/pypi?%3Aaction=list_classifiers
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
makes 3.10 the minimum supported python version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum Python requirement to 3.10+, ensuring the project now targets Python 3.10 and newer.
  * Removed the explicit Python 3.9 entry from project metadata to reflect the new supported versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->