### PR TITLE
fix: filter format suggestions with all-inclusive range

### DIFF
--- a/cpp_linter/clang_tools/clang_format.py
+++ b/cpp_linter/clang_tools/clang_format.py
@@ -139,7 +139,8 @@ def parse_format_replacements_xml(
             line, cols = get_line_cnt_from_cols(content, offset)
             is_line_in_ranges = False
             for r in ranges:
-                if line in range(r[0], r[1]):  # range is inclusive
+                # range() is partially inclusive: [r0, r1)
+                if line in range(r[0], r[1] + 1):
                     is_line_in_ranges = True
                     break
             if is_line_in_ranges or lines_changed_only == 0:

--- a/tests/capture_tools_output/test_tools_output.py
+++ b/tests/capture_tools_output/test_tools_output.py
@@ -354,7 +354,8 @@ def test_format_annotations(
             )
             for line in lines:
                 for r in ranges:  # an empty list if lines_changed_only == 0
-                    if line in range(r[0], r[1]):
+                    # range() is partially inclusive: [r0, r1)
+                    if line in range(r[0], r[1] + 1):
                         break
                 else:  # pragma: no cover
                     raise RuntimeError(f"line {line} not in ranges {repr(ranges)}")


### PR DESCRIPTION
Python's `range()` is partially inclusive (`[start, end)`). where clang-format's CLI arg `--lines` uses an all inclusive range.

Note, we already have a test that simulates the exact scenario we are trying resolve here. I just needed to adjust the validating logic so it reflects this patch's filtering logic.

refs:
- cpp-linter/cpp-linter-action#416
- cpp-linter/cpp-linter-action#388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed boundary handling for line-range checks so formatting annotations and replacements correctly match modified code regions, including single-line and end-of-range cases, preventing missed or incorrectly applied format markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->