### PR TITLE
feat: add option to write summary to file

### DIFF
--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -73,6 +73,8 @@ class Args(UserDict):
     ignore_format: str = ""
     #: See :std:option:`--passive-reviews`.
     passive_reviews: bool = False
+    #: See :std:option:`--summary-output-file`.
+    summary_output_file: str = ""
     #: A subcommand if provided
     command: str | None = None
 
@@ -385,6 +387,12 @@ _parser_args[("-R", "--passive-reviews")] = dict(
     type=lambda input: input.lower() == "true",
     help="""Set to ``true`` to prevent Pull Request
 reviews from requesting or approving changes.""",
+)
+_parser_args[("-o", "--summary-output-file")] = dict(
+    default="",
+    help="""Supply a path to write the step summary to.
+Leave empty to not write summary to a file.
+    """,
 )
 
 

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -392,7 +392,8 @@ _parser_args[("-o", "--summary-output-file")] = dict(
     default="",
     help="""Supply a path to which the step summary will be written.
 Leave empty to not write summary to a file.
-    """,
+Any relative path shall be relative to the
+:std:option:`--repo-root` path.""",
 )
 
 

--- a/cpp_linter/cli.py
+++ b/cpp_linter/cli.py
@@ -390,7 +390,7 @@ reviews from requesting or approving changes.""",
 )
 _parser_args[("-o", "--summary-output-file")] = dict(
     default="",
-    help="""Supply a path to write the step summary to.
+    help="""Supply a path to which the step summary will be written.
 Leave empty to not write summary to a file.
     """,
 )

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -240,7 +240,7 @@ class GithubApiClient(RestApiClient):
                 ) as summary:
                     summary.write(f"\n{comment}\n")
             if args.summary_output_file:
-                summary_output_path = Path(args.summary_output_file)
+                summary_output_path = Path(args.summary_output_file).resolve()
                 try:
                     summary_output_path.parent.mkdir(parents=True, exist_ok=True)
                     with summary_output_path.open(

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -11,25 +11,25 @@ designed around GitHub's REST API.
 
 import json
 import logging
+import sys
+import urllib.parse
 from os import environ
 from pathlib import Path
-import urllib.parse
-import sys
 from typing import Any, cast
 
-from ..common_fs import FileObj, CACHE_PATH
-from ..common_fs.file_filter import FileFilter
+from ..clang_tools import ClangVersions
 from ..clang_tools.clang_format import (
     formalize_style_name,
     tally_format_advice,
 )
 from ..clang_tools.clang_tidy import tally_tidy_advice
-from ..clang_tools.patcher import ReviewComments, PatchMixin
-from ..clang_tools import ClangVersions
+from ..clang_tools.patcher import PatchMixin, ReviewComments
 from ..cli import Args
-from ..loggers import logger, log_commander
-from ..git import parse_diff, get_diff
-from . import RestApiClient, USER_AGENT, USER_OUTREACH, COMMENT_MARKER, RateLimitHeaders
+from ..common_fs import CACHE_PATH, FileObj
+from ..common_fs.file_filter import FileFilter
+from ..git import get_diff, parse_diff
+from ..loggers import log_commander, logger
+from . import COMMENT_MARKER, USER_AGENT, USER_OUTREACH, RateLimitHeaders, RestApiClient
 
 RATE_LIMIT_HEADERS = RateLimitHeaders(
     reset="x-ratelimit-reset",
@@ -243,10 +243,7 @@ class GithubApiClient(RestApiClient):
                 summary_output_path = Path(args.summary_output_file).resolve()
                 try:
                     summary_output_path.parent.mkdir(parents=True, exist_ok=True)
-                    with summary_output_path.open(
-                        "w", encoding="utf-8"
-                    ) as summary_file:
-                        summary_file.write(f"\n{comment}\n")
+                    summary_output_path.write_text(f"\n{comment}\n", encoding="utf-8")
                 except OSError as e:
                     log_commander.error(
                         "Failed to write summary output file '%s': %s",

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -241,15 +241,18 @@ class GithubApiClient(RestApiClient):
                     summary.write(f"\n{comment}\n")
             if args.summary_output_file:
                 summary_output_path = Path(args.summary_output_file)
-                if summary_output_path.is_dir():
-                    log_commander.error(
-                        f"Failed to write to '{summary_output_path}': Is a directory."
-                    )
-                else:
+                try:
+                    summary_output_path.parent.mkdir(parents=True, exist_ok=True)
                     with summary_output_path.open(
                         "w", encoding="utf-8"
                     ) as summary_file:
                         summary_file.write(f"\n{comment}\n")
+                except OSError as e:
+                    log_commander.error(
+                        "Failed to write summary output file '%s': %s",
+                        summary_output_path,
+                        e,
+                    )
 
         if args.file_annotations:
             self.make_annotations(

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -244,7 +244,7 @@ class GithubApiClient(RestApiClient):
                 try:
                     summary_output_path.parent.mkdir(parents=True, exist_ok=True)
                     summary_output_path.write_text(f"\n{comment}\n", encoding="utf-8")
-                except OSError as e:
+                except (OSError, ValueError) as e:
                     log_commander.error(
                         "Failed to write summary output file '%s': %s",
                         summary_output_path,

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -11,25 +11,25 @@ designed around GitHub's REST API.
 
 import json
 import logging
-import sys
-import urllib.parse
 from os import environ
 from pathlib import Path
+import urllib.parse
+import sys
 from typing import Any, cast
 
-from ..clang_tools import ClangVersions
+from ..common_fs import FileObj, CACHE_PATH
+from ..common_fs.file_filter import FileFilter
 from ..clang_tools.clang_format import (
     formalize_style_name,
     tally_format_advice,
 )
 from ..clang_tools.clang_tidy import tally_tidy_advice
-from ..clang_tools.patcher import PatchMixin, ReviewComments
+from ..clang_tools.patcher import ReviewComments, PatchMixin
+from ..clang_tools import ClangVersions
 from ..cli import Args
-from ..common_fs import CACHE_PATH, FileObj
-from ..common_fs.file_filter import FileFilter
-from ..git import get_diff, parse_diff
-from ..loggers import log_commander, logger
-from . import COMMENT_MARKER, USER_AGENT, USER_OUTREACH, RateLimitHeaders, RestApiClient
+from ..loggers import logger, log_commander
+from ..git import parse_diff, get_diff
+from . import RestApiClient, USER_AGENT, USER_OUTREACH, COMMENT_MARKER, RateLimitHeaders
 
 RATE_LIMIT_HEADERS = RateLimitHeaders(
     reset="x-ratelimit-reset",

--- a/cpp_linter/rest_api/github_api.py
+++ b/cpp_linter/rest_api/github_api.py
@@ -224,7 +224,9 @@ class GithubApiClient(RestApiClient):
         checks_failed = format_checks_failed + tidy_checks_failed
         comment: None | str = None
 
-        if args.step_summary and "GITHUB_STEP_SUMMARY" in environ:
+        write_step_summary = args.step_summary and "GITHUB_STEP_SUMMARY" in environ
+
+        if write_step_summary or args.summary_output_file:
             comment = super().make_comment(
                 files=files,
                 format_checks_failed=format_checks_failed,
@@ -232,8 +234,22 @@ class GithubApiClient(RestApiClient):
                 clang_versions=clang_versions,
                 len_limit=None,
             )
-            with open(environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
-                summary.write(f"\n{comment}\n")
+            if write_step_summary:
+                with open(
+                    environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8"
+                ) as summary:
+                    summary.write(f"\n{comment}\n")
+            if args.summary_output_file:
+                summary_output_path = Path(args.summary_output_file)
+                if summary_output_path.is_dir():
+                    log_commander.error(
+                        f"Failed to write to '{summary_output_path}': Is a directory."
+                    )
+                else:
+                    with summary_output_path.open(
+                        "w", encoding="utf-8"
+                    ) as summary_file:
+                        summary_file.write(f"\n{comment}\n")
 
         if args.file_annotations:
             self.make_annotations(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -239,6 +239,7 @@ REQUIRED_VERSIONS = {
     "1.9.0": ["ignore_tidy", "ignore_format"],
     "1.10.0": ["passive_reviews"],
     "1.12.0": ["diff_base", "ignore_index"],
+    "1.13.0": ["summary_output_file"],
 }
 SUBCOMMAND_VERSIONS = {"version": "1.11.0"}
 

--- a/tests/comments/test_comments.py
+++ b/tests/comments/test_comments.py
@@ -66,6 +66,12 @@ def test_post_feedback(
     args.thread_comments = thread_comments
     args.step_summary = thread_comments == "update" and not no_lgtm
     args.file_annotations = thread_comments == "update" and no_lgtm
+    if thread_comments == "true":
+        # cover the summary_output_file branch with a writable file path
+        args.summary_output_file = str(tmp_path / "summary.md")
+    elif thread_comments == "false" and no_lgtm:
+        # cover the summary_output_file branch where the path is a directory
+        args.summary_output_file = str(tmp_path)
     clang_versions = capture_clang_tools_output(files, args=args)
     # add a non project file to tidy_advice to intentionally cover a log.debug()
     for file in files:
@@ -170,3 +176,10 @@ def test_post_feedback(
         caplog.set_level(logging.DEBUG, logger=logger.name)
 
         gh_client.post_feedback(files, args, clang_versions)
+
+    if args.summary_output_file:
+        summary_output_path = Path(args.summary_output_file)
+        if not summary_output_path.is_dir():
+            # regular file path -> summary was written
+            assert summary_output_path.is_file()
+            assert summary_output_path.read_text(encoding="utf-8")

--- a/tests/comments/test_comments.py
+++ b/tests/comments/test_comments.py
@@ -70,7 +70,7 @@ def test_post_feedback(
         # cover the summary_output_file branch with a writable file path
         args.summary_output_file = str(tmp_path / "summary.md")
     elif thread_comments == "false" and no_lgtm:
-        # cover the summary_output_file branch where the path is a directory
+        # cover the summary_output_file branch where the path is erroneously a directory
         args.summary_output_file = str(tmp_path)
     clang_versions = capture_clang_tools_output(files, args=args)
     # add a non project file to tidy_advice to intentionally cover a log.debug()

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -39,6 +39,18 @@ from cpp_linter.cli import get_cli_parser, Args
         ("jobs", "4", "jobs", 4),
         pytest.param("jobs", "x", "jobs", 0, marks=pytest.mark.xfail),
         ("ignore-tidy", "!src|", "ignore_tidy", "!src|"),
+        (
+            "summary-output-file",
+            "test-output-file.md",
+            "summary_output_file",
+            "test-output-file.md",
+        ),
+        (
+            "summary-output-file",
+            "",
+            "summary_output_file",
+            "",
+        ),
     ],
 )
 def test_arg_parser(


### PR DESCRIPTION
Closes #205.

- Use option `-o` or `--summary-output-file` to provide a file.
- By default the summary will not be written to a file.
- If the provided path is a directory, log an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-o/--summary-output-file` to write the generated step summary to a specified Markdown file path (use an empty value to disable file output).

* **Bug Fixes**
  * Feedback summaries are now produced when built-in step summaries are enabled and/or when a summary output file is provided.
  * When using a summary output file, missing parent directories are created and write errors are handled without crashing.

* **Tests**
  * Expanded CLI argument parsing and feedback/comment tests to cover summary file creation and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->