### PR TITLE
fix: update clang-tools install command for CLI v1.1.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install clang-tools
         run: |
           python -m pip install clang-tools
-          clang-tools install ${{ matrix.version }}
+          clang-tools install clang-format clang-tidy --version ${{ matrix.version }}
 
       - name: Is clang-only tests?
         id: clang-dep

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install clang-tools
         run: |
           python -m pip install clang-tools
-          clang-tools --install ${{ matrix.version }}
+          clang-tools install ${{ matrix.version }}
 
       - name: Is clang-only tests?
         id: clang-dep


### PR DESCRIPTION
## Description

The latest version of `clang-tools` (v1.1.0) changed its CLI interface. The old flag-based syntax `--install <version>` has been replaced with the subcommand-based syntax `install <version>`.

See the help output from the CI run:
```
usage: clang-tools [-h] {install,uninstall,version} ...
clang-tools: error: argument command: invalid choice: '16' (choose from 'install', 'uninstall', 'version')
```

Fixed CI failures from https://github.com/cpp-linter/cpp-linter/actions/runs/28257478082/job/83724117942